### PR TITLE
Create abstraction for SNI certificates in Kestrel

### DIFF
--- a/LettuceEncrypt.sln
+++ b/LettuceEncrypt.sln
@@ -33,6 +33,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LettuceEncrypt.Azure.UnitTe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KeyVault", "samples\KeyVault\KeyVault.csproj", "{6143D097-6983-4A29-9DAE-1DD0EBC900D2}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McMaster.AspNetCore.Kestrel.Certificates", "src\Kestrel.Certificates\McMaster.AspNetCore.Kestrel.Certificates.csproj", "{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -115,6 +117,18 @@ Global
 		{6143D097-6983-4A29-9DAE-1DD0EBC900D2}.Release|x64.Build.0 = Release|Any CPU
 		{6143D097-6983-4A29-9DAE-1DD0EBC900D2}.Release|x86.ActiveCfg = Release|Any CPU
 		{6143D097-6983-4A29-9DAE-1DD0EBC900D2}.Release|x86.Build.0 = Release|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Debug|x64.Build.0 = Debug|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Debug|x86.Build.0 = Debug|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Release|x64.ActiveCfg = Release|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Release|x64.Build.0 = Release|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Release|x86.ActiveCfg = Release|Any CPU
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -126,6 +140,7 @@ Global
 		{3E8A37BC-D59C-497D-A3BF-2A9740F351C7} = {CC50E6BF-ECAC-4B32-9DDF-68E0C09DEA4A}
 		{5D2D6ACA-3EE3-42C8-84D1-D9B6ABE38343} = {F832E417-FA9F-4DB4-8E82-3D56054E47B1}
 		{6143D097-6983-4A29-9DAE-1DD0EBC900D2} = {C1D11C9E-C330-450D-9FD4-13A679A3D707}
+		{8131AFC9-ED23-4A3A-9D38-5200E4D8B168} = {CC50E6BF-ECAC-4B32-9DDF-68E0C09DEA4A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {EA50A4AB-48E4-4D43-8EFD-2BC849EA7AF8}

--- a/src/Kestrel.Certificates/IServerCertificateSelector.cs
+++ b/src/Kestrel.Certificates/IServerCertificateSelector.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Security.Cryptography.X509Certificates;
+using Microsoft.AspNetCore.Connections;
+
+namespace McMaster.AspNetCore.Kestrel.Certificates
+{
+    /// <summary>
+    /// Selects a certificate for incoming TLS connections.
+    /// </summary>
+    public interface IServerCertificateSelector
+    {
+        /// <summary>
+        /// <para>
+        /// A callback that will be invoked to dynamically select a server certificate.
+        /// If SNI is not available, then the domainName parameter will be null.
+        /// </para>
+        /// <para>
+        /// If the server certificate has an Extended Key Usage extension, the usages must include Server Authentication (OID 1.3.6.1.5.5.7.3.1).
+        /// </para>
+        /// </summary>
+        X509Certificate2? Select(ConnectionContext context, string? domainName);
+    }
+}

--- a/src/Kestrel.Certificates/KestrelHttpsOptionsExtensions.cs
+++ b/src/Kestrel.Certificates/KestrelHttpsOptionsExtensions.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using McMaster.AspNetCore.Kestrel.Certificates;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.AspNetCore.Hosting
+{
+    /// <summary>
+    /// API for configuring Kestrel certificiate options
+    /// </summary>
+    public static class KestrelHttpsOptionsExtensions
+    {
+        /// <summary>
+        /// Configure HTTPS certificates dynamically with an implementation of <see cref="IServerCertificateSelector"/>.
+        /// </summary>
+        /// <param name="httpsOptions">The HTTPS configuration</param>
+        /// <param name="certificateSelector">The server certificate selector.</param>
+        /// <returns>The HTTPS configuration</returns>
+        public static HttpsConnectionAdapterOptions UseServerCertificateSelector(
+            this HttpsConnectionAdapterOptions httpsOptions,
+            IServerCertificateSelector certificateSelector)
+        {
+            httpsOptions.ServerCertificateSelector = certificateSelector.Select;
+            return httpsOptions;
+        }
+    }
+}

--- a/src/Kestrel.Certificates/McMaster.AspNetCore.Kestrel.Certificates.csproj
+++ b/src/Kestrel.Certificates/McMaster.AspNetCore.Kestrel.Certificates.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <Description>A class library for managing HTTPS certificates with ASP.NET Core.</Description>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <PackageVersion>$(VersionPrefix)</PackageVersion>
+    <PackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PackageVersion)-$(VersionSuffix)</PackageVersion>
+  </PropertyGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.2" />
+  </ItemGroup>
+
+</Project>

--- a/src/Kestrel.Certificates/PublicAPI.Shipped.txt
+++ b/src/Kestrel.Certificates/PublicAPI.Shipped.txt
@@ -1,0 +1,1 @@
+#nullable enable

--- a/src/Kestrel.Certificates/PublicAPI.Unshipped.txt
+++ b/src/Kestrel.Certificates/PublicAPI.Unshipped.txt
@@ -1,0 +1,5 @@
+#nullable enable
+McMaster.AspNetCore.Kestrel.Certificates.IServerCertificateSelector
+McMaster.AspNetCore.Kestrel.Certificates.IServerCertificateSelector.Select(Microsoft.AspNetCore.Connections.ConnectionContext! context, string? domainName) -> System.Security.Cryptography.X509Certificates.X509Certificate2?
+Microsoft.AspNetCore.Hosting.KestrelHttpsOptionsExtensions
+static Microsoft.AspNetCore.Hosting.KestrelHttpsOptionsExtensions.UseServerCertificateSelector(this Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions! httpsOptions, McMaster.AspNetCore.Kestrel.Certificates.IServerCertificateSelector! certificateSelector) -> Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions!

--- a/src/LettuceEncrypt/Internal/CertificateSelector.cs
+++ b/src/LettuceEncrypt/Internal/CertificateSelector.cs
@@ -6,13 +6,14 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
+using McMaster.AspNetCore.Kestrel.Certificates;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace LettuceEncrypt.Internal
 {
-    internal class CertificateSelector
+    internal class CertificateSelector : IServerCertificateSelector
     {
         private readonly ConcurrentDictionary<string, X509Certificate2> _certs =
             new ConcurrentDictionary<string, X509Certificate2>(StringComparer.OrdinalIgnoreCase);

--- a/src/LettuceEncrypt/Internal/KestrelOptionsSetup.cs
+++ b/src/LettuceEncrypt/Internal/KestrelOptionsSetup.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
+using McMaster.AspNetCore.Kestrel.Certificates;
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Options;
 
@@ -9,10 +11,10 @@ namespace LettuceEncrypt.Internal
 {
     internal class KestrelOptionsSetup : IConfigureOptions<KestrelServerOptions>
     {
-        private readonly CertificateSelector _certificateSelector;
+        private readonly IServerCertificateSelector _certificateSelector;
         private readonly TlsAlpnChallengeResponder _tlsAlpnChallengeResponder;
 
-        public KestrelOptionsSetup(CertificateSelector certificateSelector, TlsAlpnChallengeResponder tlsAlpnChallengeResponder)
+        public KestrelOptionsSetup(IServerCertificateSelector certificateSelector, TlsAlpnChallengeResponder tlsAlpnChallengeResponder)
         {
             _certificateSelector = certificateSelector ?? throw new ArgumentNullException(nameof(certificateSelector));
             _tlsAlpnChallengeResponder = tlsAlpnChallengeResponder ?? throw new ArgumentNullException(nameof(tlsAlpnChallengeResponder));
@@ -28,7 +30,7 @@ namespace LettuceEncrypt.Internal
 #else
 #error Update TFMs
 #endif
-                o.ServerCertificateSelector = _certificateSelector.Select;
+                o.UseServerCertificateSelector(_certificateSelector);
             });
         }
     }

--- a/src/LettuceEncrypt/LettuceEncrypt.csproj
+++ b/src/LettuceEncrypt/LettuceEncrypt.csproj
@@ -30,9 +30,12 @@ This only works with Kestrel, which is the default server configuration for ASP.
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel.Core" Version="2.1.2" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.1" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Kestrel.Certificates\McMaster.AspNetCore.Kestrel.Certificates.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/LettuceEncrypt/LettuceEncryptServiceCollectionExtensions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptServiceCollectionExtensions.cs
@@ -6,6 +6,7 @@ using LettuceEncrypt;
 using LettuceEncrypt.Acme;
 using LettuceEncrypt.Internal;
 using LettuceEncrypt.Internal.IO;
+using McMaster.AspNetCore.Kestrel.Certificates;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
@@ -44,7 +45,9 @@ namespace Microsoft.Extensions.DependencyInjection
 
             services.TryAddSingleton<ICertificateAuthorityConfiguration, DefaultCertificateAuthorityConfiguration>();
 
-            services.AddSingleton<CertificateSelector>()
+            services
+                .AddSingleton<CertificateSelector>()
+                .AddSingleton<IServerCertificateSelector>(s => s.GetRequiredService<CertificateSelector>())
                 .AddSingleton<IConsole>(PhysicalConsole.Singleton)
                 .AddSingleton<IClock, SystemClock>()
                 .AddSingleton<TermsOfServiceChecker>()

--- a/test/LettuceEncrypt.UnitTests/KestrelOptionsSetupTests.cs
+++ b/test/LettuceEncrypt.UnitTests/KestrelOptionsSetupTests.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Reflection;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace LettuceEncrypt.UnitTests
+{
+    public class KestrelOptionsSetupTests
+    {
+        [Fact]
+        public void ItSetsCertificateSelector()
+        {
+            var services = new ServiceCollection()
+                .AddLogging()
+                .AddLettuceEncrypt()
+                .Services
+                .BuildServiceProvider(validateScopes: true);
+
+            var kestrelOptions = services.GetRequiredService<IOptions<KestrelServerOptions>>().Value;
+            // reflection is gross, but there is no public API for this so (shrug)
+            var httpsDefaultsProp =
+                typeof(KestrelServerOptions).GetProperty("HttpsDefaults",
+                    BindingFlags.Instance | BindingFlags.NonPublic);
+            var httpsDefaultsFunc =
+                (Action<HttpsConnectionAdapterOptions>) httpsDefaultsProp.GetMethod.Invoke(kestrelOptions,
+                    Array.Empty<object>());
+            var httpsDefaults = new HttpsConnectionAdapterOptions();
+
+            Assert.Null(httpsDefaults.ServerCertificateSelector);
+
+            httpsDefaultsFunc(httpsDefaults);
+
+            Assert.NotNull(httpsDefaults.ServerCertificateSelector);
+        }
+    }
+}


### PR DESCRIPTION
This extracts API which could be useful for managing certificates dynamically with Kestrel, not just for those using Let's Encrypt.

Lays foundation (but does not complete work) for resolving https://github.com/natemcmaster/LettuceEncrypt/issues/100