### PR TITLE
Add API to configure LettuceEncrypt on Kestrel's HTTPS option

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,12 @@ A few required options should be set, typically via the appsettings.json file.
 
 ### Kestrel configuration
 
-If your code is using the `.UseKestrel` method to configure address/port and/or HTTPS settings, you will need to
-also add a call to enable Lettuce Encrypt. This is required, otherwise LettuceEncrypt certificate automation
-will not be configured correctly with the rest of your HTTPS settings.
+If your code is using the `.UseKestrel()` method to configure IP addresses, ports, or HTTPS settings,
+you will also need to call `UseLettuceEncrypt`. This is required to make Lettuce Encrypt work.
 
-Common example: if calling `ConfigureHttpsDefaults`, you need to add `UseLettuceEncrypt` like this:
+#### Example: ConfigureHttpsDefaults
+
+If calling `ConfigureHttpsDefaults`, use `UseLettuceEncrypt` like this:
 
 ```c#
 webBuilder.UseKestrel(k =>
@@ -98,15 +99,15 @@ webBuilder.UseKestrel(k =>
 });
 ```
 
-Likewise, for any usage of `.UseHttps`
-
-Common example: if calling `ConfigureHttpsDefaults`, you need to add `UseLettuceEncrypt` like this:
+#### Example: Listen + UseHttps
+If using `Listen` + `UseHttps` to manually configure Kestrel's address binding, use `UseLettuceEncrypt` like this:
 
 ```c#
 webBuilder.UseKestrel(k =>
 {
     var appServices = k.ApplicationServices;
-    k.Listen(IPAddress.Any, 443,
+    k.Listen(
+        IPAddress.Any, 443,
         o => o.UseHttps(h =>
         {
             h.UseLettuceEncrypt(appServices);

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ When enabled, your web server will **automatically** generate an HTTPS certifica
 It then configures Kestrel to use this certificate for all HTTPS traffic.
 See [usage instructions below](#usage) to get started.
 
-Created and developed by [@natemcmaster](https://github.com/natemcmaster) with ❤️from Seattle ☕️.
+Created and developed by [@natemcmaster](https://github.com/natemcmaster) with ❤️ from Seattle ☕️.
 This project was formerly known as "McMaster.AspNetCore.LetsEncrypt", but [has been renamed for
 trademark reasons](https://github.com/natemcmaster/LettuceEncrypt/issues/99). This project is **not an official
 offering** from Let's Encrypt® or ISRG™.
@@ -77,6 +77,44 @@ A few required options should be set, typically via the appsettings.json file.
 ```
 
 ## Additional options
+
+### Kestrel configuration
+
+If your code is using the `.UseKestrel` method to configure address/port and/or HTTPS settings, you will need to
+also add a call to enable Lettuce Encrypt. This is required, otherwise LettuceEncrypt certificate automation
+will not be configured correctly with the rest of your HTTPS settings.
+
+Common example: if calling `ConfigureHttpsDefaults`, you need to add `UseLettuceEncrypt` like this:
+
+```c#
+webBuilder.UseKestrel(k =>
+{
+    var appServices = k.ApplicationServices;
+    k.ConfigureHttpsDefaults(h =>
+    {
+        h.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
+        h.UseLettuceEncrypt(appServices);
+    });
+});
+```
+
+Likewise, for any usage of `.UseHttps`
+
+Common example: if calling `ConfigureHttpsDefaults`, you need to add `UseLettuceEncrypt` like this:
+
+```c#
+webBuilder.UseKestrel(k =>
+{
+    var appServices = k.ApplicationServices;
+    k.Listen(IPAddress.Any, 443,
+        o => o.UseHttps(h =>
+        {
+            h.UseLettuceEncrypt(appServices);
+        }));
+});
+```
+
+### Customizing storage
 
 Certificates are stored to the machine's X.509 store by default. Certificates can be stored in additional
 locations by using extension methods after calling `AddLettuceEncrypt()` in the `Startup` class.

--- a/samples/Web/Program.cs
+++ b/samples/Web/Program.cs
@@ -1,4 +1,7 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿using System;
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
 using Microsoft.Extensions.Hosting;
 
 namespace Web
@@ -15,6 +18,35 @@ namespace Web
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
                     webBuilder.UseStartup<Startup>();
+
+                    // This example shows how to configure Kestrel's client certificate requirements along with
+                    // enabling Lettuce Encrypt's certificate automation.
+                    if (Environment.GetEnvironmentVariable("REQUIRE_CLIENT_CERT") == "true")
+                    {
+                        webBuilder.UseKestrel(k =>
+                        {
+                            var appServices = k.ApplicationServices;
+                            k.ConfigureHttpsDefaults(h =>
+                            {
+                                h.ClientCertificateMode = ClientCertificateMode.RequireCertificate;
+                                h.UseLettuceEncrypt(appServices);
+                            });
+                        });
+                    }
+
+                    // This example shows how to configure Kestrel's address/port binding along with
+                    // enabling Lettuce Encrypt's certificate automation.
+                    if (Environment.GetEnvironmentVariable("CONFIG_KESTREL_VIA_CODE") == "true")
+                    {
+                        webBuilder.PreferHostingUrls(false);
+                        webBuilder.UseKestrel(k =>
+                        {
+                            var appServices = k.ApplicationServices;
+                            k.Listen(IPAddress.Any, 443,
+                                o =>
+                                    o.UseHttps(h => h.UseLettuceEncrypt(appServices)));
+                        });
+                    }
                 });
     }
 }

--- a/src/LettuceEncrypt/Internal/KestrelOptionsSetup.cs
+++ b/src/LettuceEncrypt/Internal/KestrelOptionsSetup.cs
@@ -25,12 +25,12 @@ namespace LettuceEncrypt.Internal
             options.ConfigureHttpsDefaults(o =>
             {
 #if NETCOREAPP3_0
-                o.OnAuthenticate = _tlsAlpnChallengeResponder.OnSslAuthenticate;
+                o.UseLettuceEncrypt(_certificateSelector, _tlsAlpnChallengeResponder);
 #elif NETSTANDARD2_0
+                o.UseServerCertificateSelector(_certificateSelector);
 #else
 #error Update TFMs
 #endif
-                o.UseServerCertificateSelector(_certificateSelector);
             });
         }
     }

--- a/src/LettuceEncrypt/LettuceEncryptKestrelHttpsOptionsExtensions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptKestrelHttpsOptionsExtensions.cs
@@ -1,0 +1,74 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using LettuceEncrypt.Internal;
+using McMaster.AspNetCore.Kestrel.Certificates;
+using Microsoft.AspNetCore.Server.Kestrel.Https;
+using Microsoft.Extensions.DependencyInjection;
+
+// ReSharper disable once CheckNamespace
+namespace Microsoft.AspNetCore.Hosting
+{
+    /// <summary>
+    /// Methods for configuring Kestrel.
+    /// </summary>
+    public static class LettuceEncryptKestrelHttpsOptionsExtensions
+    {
+        private const string MissingServicesMessage =
+            "Missing required LettuceEncrypt services. Did you call '.AddLettuceEncrypt()' to add these your DI container?";
+
+        /// <summary>
+        /// Configured LettuceEncrypt on this HTTPS endpoint for Kestrel.
+        /// </summary>
+        /// <param name="httpsOptions">Kestrel's HTTPS configuration</param>
+        /// <param name="applicationServices"></param>
+        /// <returns>The original HTTPS options with some required settings added to it.</returns>
+        /// <exception cref="InvalidOperationException">
+        /// Raised if <see cref="LettuceEncryptServiceCollectionExtensions.AddLettuceEncrypt(Microsoft.Extensions.DependencyInjection.IServiceCollection)"/>
+        /// has not been used to add required services to the application service provider
+        /// </exception>
+        public static HttpsConnectionAdapterOptions UseLettuceEncrypt(
+            this HttpsConnectionAdapterOptions httpsOptions,
+            IServiceProvider applicationServices)
+        {
+            var selector = applicationServices.GetService<IServerCertificateSelector>();
+
+            if (selector is null)
+            {
+                throw new InvalidOperationException(MissingServicesMessage);
+            }
+
+#if NETCOREAPP3_0
+            var tlsResponder = applicationServices.GetService<TlsAlpnChallengeResponder>();
+            if (tlsResponder is null)
+            {
+                throw new InvalidOperationException(MissingServicesMessage);
+            }
+
+            return httpsOptions.UseLettuceEncrypt(selector, tlsResponder);
+
+#elif NETSTANDARD2_0
+            return httpsOptions.UseServerCertificateSelector(selector);
+#else
+#error Update TFMs
+#endif
+        }
+
+#if NETCOREAPP3_0
+        internal static HttpsConnectionAdapterOptions UseLettuceEncrypt(
+            this HttpsConnectionAdapterOptions httpsOptions,
+            IServerCertificateSelector selector,
+            TlsAlpnChallengeResponder tlsAlpnChallengeResponder
+        )
+        {
+            httpsOptions.OnAuthenticate = tlsAlpnChallengeResponder.OnSslAuthenticate;
+            httpsOptions.UseServerCertificateSelector(selector);
+            return httpsOptions;
+        }
+#elif NETSTANDARD2_0
+#else
+#error Update TFMs
+#endif
+    }
+}

--- a/src/LettuceEncrypt/PublicAPI.Unshipped.txt
+++ b/src/LettuceEncrypt/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
 #nullable enable
 LettuceEncrypt.Acme.ICertificateAuthorityConfiguration
 LettuceEncrypt.Acme.ICertificateAuthorityConfiguration.AcmeDirectoryUri.get -> System.Uri!
+Microsoft.AspNetCore.Hosting.LettuceEncryptKestrelHttpsOptionsExtensions
+static Microsoft.AspNetCore.Hosting.LettuceEncryptKestrelHttpsOptionsExtensions.UseLettuceEncrypt(this Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions! httpsOptions, System.IServiceProvider! applicationServices) -> Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions!


### PR DESCRIPTION
Resolves #100

This adds new API for scenarios when dependency injection is insufficient
to configure server certificate selection and TLS authentication callbacks.