### PR TITLE
Begin to refactor ACME certificate generation into the state pattern

### DIFF
--- a/src/LettuceEncrypt/Internal/AcmeCertificateLoader.cs
+++ b/src/LettuceEncrypt/Internal/AcmeCertificateLoader.cs
@@ -2,15 +2,14 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
-using LettuceEncrypt.Internal.IO;
+using LettuceEncrypt.Internal.AcmeStates;
 using Microsoft.AspNetCore.Hosting.Server;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
 using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -18,39 +17,29 @@ using Microsoft.Extensions.Options;
 namespace LettuceEncrypt.Internal
 {
     /// <summary>
-    /// Loads certificates for all configured hostnames
+    /// This starts the ACME state machine, which handles certificate generation and renewal
     /// </summary>
     internal class AcmeCertificateLoader : BackgroundService
     {
-        private readonly AcmeCertificateFactory _acmeCertificateFactory;
-        private readonly CertificateSelector _selector;
+        private readonly IServiceScopeFactory _serviceScopeFactory;
         private readonly IOptions<LettuceEncryptOptions> _options;
         private readonly ILogger _logger;
 
         private readonly IServer _server;
         private readonly IConfiguration _config;
-        private readonly IEnumerable<ICertificateRepository> _certificateRepositories;
-        private readonly IClock _clock;
-        private const string ErrorMessage = "Failed to create certificate";
 
         public AcmeCertificateLoader(
-            AcmeCertificateFactory acmeCertificateFactory,
-            CertificateSelector selector,
+            IServiceScopeFactory serviceScopeFactory,
             IOptions<LettuceEncryptOptions> options,
             ILogger<AcmeCertificateLoader> logger,
             IServer server,
-            IConfiguration config,
-            IEnumerable<ICertificateRepository> certificateRepositories,
-            IClock clock)
+            IConfiguration config)
         {
-            _acmeCertificateFactory = acmeCertificateFactory;
-            _selector = selector;
+            _serviceScopeFactory = serviceScopeFactory;
             _options = options;
             _logger = logger;
             _server = server;
             _config = config;
-            _certificateRepositories = certificateRepositories;
-            _clock = clock;
         }
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
@@ -73,153 +62,42 @@ namespace LettuceEncrypt.Internal
             }
 
             // load certificates in the background
-
             if (!LettuceEncryptDomainNamesWereConfigured())
             {
                 _logger.LogInformation("No domain names were configured");
                 return;
             }
 
-            await Task.Run(async () =>
-            {
-                try
-                {
-                    await LoadCerts(stoppingToken);
-                }
-                catch (AggregateException ex) when (ex.InnerException != null)
-                {
-                    _logger.LogError(0, ex.InnerException, ErrorMessage);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(0, ex, ErrorMessage);
-                }
+            using var acmeStateMachineScope = _serviceScopeFactory.CreateScope();
 
-                await MonitorRenewal(stoppingToken);
-            }, stoppingToken);
+            try
+            {
+                IAcmeState state = acmeStateMachineScope.ServiceProvider.GetRequiredService<ServerStartupState>();
+
+                while (!stoppingToken.IsCancellationRequested)
+                {
+                    _logger.LogTrace("ACME state transition: moving to {stateName}", state.GetType().Name);
+                    state = await state.MoveNextAsync(stoppingToken);
+                }
+            }
+            catch (OperationCanceledException)
+            {
+                _logger.LogDebug("State machine cancellation requested. Exiting...");
+            }
+            catch (AggregateException ex) when (ex.InnerException != null)
+            {
+                _logger.LogError(0, ex.InnerException, "ACME state machine encountered unhandled error");
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(0, ex, "ACME state machine encountered unhandled error");
+            }
         }
 
         private bool LettuceEncryptDomainNamesWereConfigured()
         {
             return _options.Value.DomainNames
                 .Any(w => !string.Equals("localhost", w, StringComparison.OrdinalIgnoreCase));
-        }
-
-        private async Task LoadCerts(CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            var domainNames = _options.Value.DomainNames;
-            var hasCertForAllDomains = domainNames.All(_selector.HasCertForDomain);
-            if (hasCertForAllDomains)
-            {
-                _logger.LogDebug("Certificate for {domainNames} already found.", domainNames);
-                return;
-            }
-
-            await CreateCertificateAsync(domainNames, cancellationToken);
-        }
-
-        private async Task CreateCertificateAsync(string[] domainNames, CancellationToken cancellationToken)
-        {
-            var account = await _acmeCertificateFactory.GetOrCreateAccountAsync(cancellationToken);
-            _logger.LogInformation("Using account {accountId}", account.Id);
-
-            try
-            {
-                _logger.LogInformation("Creating certificate for {hostname}",
-                    string.Join(",", domainNames));
-
-                var cert = await _acmeCertificateFactory.CreateCertificateAsync(cancellationToken);
-
-                _logger.LogInformation("Created certificate {subjectName} ({thumbprint})",
-                    cert.Subject,
-                    cert.Thumbprint);
-
-                await SaveCertificateAsync(cert, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(0, ex, "Failed to automatically create a certificate for {hostname}", domainNames);
-                throw;
-            }
-        }
-
-        private async Task SaveCertificateAsync(X509Certificate2 cert, CancellationToken cancellationToken)
-        {
-            _selector.Add(cert);
-
-            var saveTasks = new List<Task>
-            {
-                Task.Delay(TimeSpan.FromMinutes(5), cancellationToken)
-            };
-
-            var errors = new List<Exception>();
-            foreach (var repo in _certificateRepositories)
-            {
-                try
-                {
-                    saveTasks.Add(repo.SaveAsync(cert, cancellationToken));
-                }
-                catch (Exception ex)
-                {
-                    // synchronous saves may fail immediately
-                    errors.Add(ex);
-                }
-            }
-
-            await Task.WhenAll(saveTasks);
-
-            if (errors.Count > 0)
-            {
-                throw new AggregateException("Failed to save cert to repositories", errors);
-            }
-        }
-
-        private async Task MonitorRenewal(CancellationToken cancellationToken)
-        {
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                var checkPeriod = _options.Value.RenewalCheckPeriod;
-                var daysInAdvance = _options.Value.RenewDaysInAdvance;
-                if (!checkPeriod.HasValue || !daysInAdvance.HasValue)
-                {
-                    _logger.LogInformation("Automatic certificate renewal is not configured. Stopping {service}",
-                        nameof(AcmeCertificateLoader));
-                    return;
-                }
-
-                await Task.Delay(checkPeriod.Value, cancellationToken);
-
-                try
-                {
-                    var domainNames = _options.Value.DomainNames;
-                    if (_logger.IsEnabled(LogLevel.Debug))
-                    {
-                        _logger.LogDebug("Checking certificates' renewals for {hostname}",
-                            string.Join(", ", domainNames));
-                    }
-
-                    foreach (var domainName in domainNames)
-                    {
-                        if (!_selector.TryGet(domainName, out var cert)
-                            || cert == null
-                            || cert.NotAfter <= _clock.Now.DateTime + daysInAdvance.Value)
-                        {
-                            await CreateCertificateAsync(domainNames, cancellationToken);
-                            break;
-                        }
-                    }
-                }
-                catch (AggregateException ex) when (ex.InnerException != null)
-                {
-                    _logger.LogError(0, ex.InnerException, ErrorMessage);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(0, ex, ErrorMessage);
-                }
-            }
         }
     }
 }

--- a/src/LettuceEncrypt/Internal/AcmeStates/AcmeState.cs
+++ b/src/LettuceEncrypt/Internal/AcmeStates/AcmeState.cs
@@ -1,0 +1,62 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace LettuceEncrypt.Internal.AcmeStates
+{
+    internal interface IAcmeState
+    {
+        Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken);
+    }
+
+    internal class TerminalState : IAcmeState
+    {
+        public static TerminalState Singleton { get; } = new TerminalState();
+
+        private TerminalState() {}
+
+        public Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken)
+        {
+            throw new OperationCanceledException();
+        }
+    }
+
+    internal abstract class AcmeState : IAcmeState
+    {
+        private readonly AcmeStateMachineContext _context;
+
+        public AcmeState(AcmeStateMachineContext context)
+        {
+            _context = context;
+        }
+
+        public abstract Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken);
+
+        protected T MoveTo<T>() where T : IAcmeState
+        {
+            return _context.Services.GetRequiredService<T>();
+        }
+    }
+
+    internal abstract class SyncAcmeState : AcmeState
+    {
+        protected SyncAcmeState(AcmeStateMachineContext context) : base(context)
+        {
+        }
+
+        public override Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var next = MoveNext();
+
+            return Task.FromResult(next);
+        }
+
+        public abstract IAcmeState MoveNext();
+    }
+}

--- a/src/LettuceEncrypt/Internal/AcmeStates/AcmeStateMachineContext.cs
+++ b/src/LettuceEncrypt/Internal/AcmeStates/AcmeStateMachineContext.cs
@@ -1,0 +1,17 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace LettuceEncrypt.Internal.AcmeStates
+{
+    internal class AcmeStateMachineContext
+    {
+        public IServiceProvider Services { get; }
+
+        public AcmeStateMachineContext(IServiceProvider services)
+        {
+            Services = services;
+        }
+    }
+}

--- a/src/LettuceEncrypt/Internal/AcmeStates/BeginCertificateCreationState.cs
+++ b/src/LettuceEncrypt/Internal/AcmeStates/BeginCertificateCreationState.cs
@@ -1,0 +1,97 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using LettuceEncrypt.Internal.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace LettuceEncrypt.Internal.AcmeStates
+{
+    internal class BeginCertificateCreationState : AcmeState
+    {
+        private readonly ILogger<ServerStartupState> _logger;
+        private readonly IOptions<LettuceEncryptOptions> _options;
+        private readonly AcmeCertificateFactory _acmeCertificateFactory;
+        private readonly CertificateSelector _selector;
+        private readonly IEnumerable<ICertificateRepository> _certificateRepositories;
+        private readonly IClock _clock;
+
+        public BeginCertificateCreationState(AcmeStateMachineContext context, ILogger<ServerStartupState> logger,
+            IOptions<LettuceEncryptOptions> options, AcmeCertificateFactory acmeCertificateFactory,
+            CertificateSelector selector, IEnumerable<ICertificateRepository> certificateRepositories,
+            IClock clock) : base(context)
+        {
+            _logger = logger;
+            _options = options;
+            _acmeCertificateFactory = acmeCertificateFactory;
+            _selector = selector;
+            _certificateRepositories = certificateRepositories;
+            _clock = clock;
+        }
+
+        public override async Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken)
+        {
+            var domainNames = _options.Value.DomainNames;
+
+            try
+            {
+                var account = await _acmeCertificateFactory.GetOrCreateAccountAsync(cancellationToken);
+                _logger.LogInformation("Using account {accountId}", account.Id);
+
+                _logger.LogInformation("Creating certificate for {hostname}",
+                    string.Join(",", domainNames));
+
+                var cert = await _acmeCertificateFactory.CreateCertificateAsync(cancellationToken);
+
+                _logger.LogInformation("Created certificate {subjectName} ({thumbprint})",
+                    cert.Subject,
+                    cert.Thumbprint);
+
+                await SaveCertificateAsync(cert, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(0, ex, "Failed to automatically create a certificate for {hostname}", domainNames);
+                throw;
+            }
+
+            return MoveTo<CheckForRenewalState>();
+        }
+
+        private async Task SaveCertificateAsync(X509Certificate2 cert, CancellationToken cancellationToken)
+        {
+            _selector.Add(cert);
+
+            var saveTasks = new List<Task>
+            {
+                Task.Delay(TimeSpan.FromMinutes(5), cancellationToken)
+            };
+
+            var errors = new List<Exception>();
+            foreach (var repo in _certificateRepositories)
+            {
+                try
+                {
+                    saveTasks.Add(repo.SaveAsync(cert, cancellationToken));
+                }
+                catch (Exception ex)
+                {
+                    // synchronous saves may fail immediately
+                    errors.Add(ex);
+                }
+            }
+
+            await Task.WhenAll(saveTasks);
+
+            if (errors.Count > 0)
+            {
+                throw new AggregateException("Failed to save cert to repositories", errors);
+            }
+        }
+    }
+}

--- a/src/LettuceEncrypt/Internal/AcmeStates/CheckForRenewalState.cs
+++ b/src/LettuceEncrypt/Internal/AcmeStates/CheckForRenewalState.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using LettuceEncrypt.Internal.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace LettuceEncrypt.Internal.AcmeStates
+{
+    class CheckForRenewalState : AcmeState
+    {
+        private readonly ILogger<CheckForRenewalState> _logger;
+        private readonly IOptions<LettuceEncryptOptions> _options;
+        private readonly CertificateSelector _selector;
+        private readonly IClock _clock;
+
+        public CheckForRenewalState(
+            AcmeStateMachineContext context,
+            ILogger<CheckForRenewalState> logger,
+            IOptions<LettuceEncryptOptions> options,
+            CertificateSelector selector,
+            IClock clock) : base(context)
+        {
+            _logger = logger;
+            _options = options;
+            _selector = selector;
+            _clock = clock;
+        }
+
+        public override async Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var checkPeriod = _options.Value.RenewalCheckPeriod;
+                var daysInAdvance = _options.Value.RenewDaysInAdvance;
+                if (!checkPeriod.HasValue || !daysInAdvance.HasValue)
+                {
+                    _logger.LogInformation("Automatic certificate renewal is not configured. Stopping {service}",
+                        nameof(AcmeCertificateLoader));
+                    return MoveTo<TerminalState>();
+                }
+
+                await Task.Delay(checkPeriod.Value, cancellationToken);
+
+                var domainNames = _options.Value.DomainNames;
+                if (_logger.IsEnabled(LogLevel.Debug))
+                {
+                    _logger.LogDebug("Checking certificates' renewals for {hostname}",
+                        string.Join(", ", domainNames));
+                }
+
+                foreach (var domainName in domainNames)
+                {
+                    if (!_selector.TryGet(domainName, out var cert)
+                        || cert == null
+                        || cert.NotAfter <= _clock.Now.DateTime + daysInAdvance.Value)
+                    {
+                        return MoveTo<BeginCertificateCreationState>();
+                    }
+                }
+            }
+
+            return MoveTo<TerminalState>();
+        }
+    }
+}

--- a/src/LettuceEncrypt/Internal/AcmeStates/ServerStartupState.cs
+++ b/src/LettuceEncrypt/Internal/AcmeStates/ServerStartupState.cs
@@ -1,181 +1,41 @@
 // Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
-using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Security.Cryptography.X509Certificates;
-using System.Threading;
-using System.Threading.Tasks;
-using LettuceEncrypt.Internal.IO;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 
 namespace LettuceEncrypt.Internal.AcmeStates
 {
-    internal class ServerStartupState : AcmeState
+    internal class ServerStartupState : SyncAcmeState
     {
-        private readonly ILogger<ServerStartupState> _logger;
         private readonly IOptions<LettuceEncryptOptions> _options;
-        private readonly AcmeCertificateFactory _acmeCertificateFactory;
         private readonly CertificateSelector _selector;
-        private readonly IEnumerable<ICertificateRepository> _certificateRepositories;
-        private readonly IClock _clock;
+        private readonly ILogger<ServerStartupState> _logger;
 
         public ServerStartupState(
             AcmeStateMachineContext context,
-            ILogger<ServerStartupState> logger,
             IOptions<LettuceEncryptOptions> options,
-            AcmeCertificateFactory acmeCertificateFactory,
             CertificateSelector selector,
-            IEnumerable<ICertificateRepository> certificateRepositories,
-            IClock clock)
-            : base(context)
+            ILogger<ServerStartupState> logger) :
+            base(context)
         {
-            _logger = logger;
             _options = options;
-            _acmeCertificateFactory = acmeCertificateFactory;
             _selector = selector;
-            _certificateRepositories = certificateRepositories;
-            _clock = clock;
+            _logger = logger;
         }
 
-        private const string ErrorMessage = "Failed to create certificate";
-
-        public override async Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken)
+        public override IAcmeState MoveNext()
         {
-            try
-            {
-                await LoadCerts(cancellationToken);
-            }
-            catch (AggregateException ex) when (ex.InnerException != null)
-            {
-                _logger.LogError(0, ex.InnerException, ErrorMessage);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(0, ex, ErrorMessage);
-            }
-
-            await MonitorRenewal(cancellationToken);
-            return this;
-        }
-
-        private async Task LoadCerts(CancellationToken cancellationToken)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
             var domainNames = _options.Value.DomainNames;
             var hasCertForAllDomains = domainNames.All(_selector.HasCertForDomain);
             if (hasCertForAllDomains)
             {
                 _logger.LogDebug("Certificate for {domainNames} already found.", domainNames);
-                return;
+                return MoveTo<CheckForRenewalState>();
             }
 
-            await CreateCertificateAsync(domainNames, cancellationToken);
-        }
-
-        private async Task CreateCertificateAsync(string[] domainNames, CancellationToken cancellationToken)
-        {
-            var account = await _acmeCertificateFactory.GetOrCreateAccountAsync(cancellationToken);
-            _logger.LogInformation("Using account {accountId}", account.Id);
-
-            try
-            {
-                _logger.LogInformation("Creating certificate for {hostname}",
-                    string.Join(",", domainNames));
-
-                var cert = await _acmeCertificateFactory.CreateCertificateAsync(cancellationToken);
-
-                _logger.LogInformation("Created certificate {subjectName} ({thumbprint})",
-                    cert.Subject,
-                    cert.Thumbprint);
-
-                await SaveCertificateAsync(cert, cancellationToken);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogError(0, ex, "Failed to automatically create a certificate for {hostname}", domainNames);
-                throw;
-            }
-        }
-
-        private async Task SaveCertificateAsync(X509Certificate2 cert, CancellationToken cancellationToken)
-        {
-            _selector.Add(cert);
-
-            var saveTasks = new List<Task>
-            {
-                Task.Delay(TimeSpan.FromMinutes(5), cancellationToken)
-            };
-
-            var errors = new List<Exception>();
-            foreach (var repo in _certificateRepositories)
-            {
-                try
-                {
-                    saveTasks.Add(repo.SaveAsync(cert, cancellationToken));
-                }
-                catch (Exception ex)
-                {
-                    // synchronous saves may fail immediately
-                    errors.Add(ex);
-                }
-            }
-
-            await Task.WhenAll(saveTasks);
-
-            if (errors.Count > 0)
-            {
-                throw new AggregateException("Failed to save cert to repositories", errors);
-            }
-        }
-
-        private async Task MonitorRenewal(CancellationToken cancellationToken)
-        {
-            while (!cancellationToken.IsCancellationRequested)
-            {
-                var checkPeriod = _options.Value.RenewalCheckPeriod;
-                var daysInAdvance = _options.Value.RenewDaysInAdvance;
-                if (!checkPeriod.HasValue || !daysInAdvance.HasValue)
-                {
-                    _logger.LogInformation("Automatic certificate renewal is not configured. Stopping {service}",
-                        nameof(AcmeCertificateLoader));
-                    return;
-                }
-
-                await Task.Delay(checkPeriod.Value, cancellationToken);
-
-                try
-                {
-                    var domainNames = _options.Value.DomainNames;
-                    if (_logger.IsEnabled(LogLevel.Debug))
-                    {
-                        _logger.LogDebug("Checking certificates' renewals for {hostname}",
-                            string.Join(", ", domainNames));
-                    }
-
-                    foreach (var domainName in domainNames)
-                    {
-                        if (!_selector.TryGet(domainName, out var cert)
-                            || cert == null
-                            || cert.NotAfter <= _clock.Now.DateTime + daysInAdvance.Value)
-                        {
-                            await CreateCertificateAsync(domainNames, cancellationToken);
-                            break;
-                        }
-                    }
-                }
-                catch (AggregateException ex) when (ex.InnerException != null)
-                {
-                    _logger.LogError(0, ex.InnerException, ErrorMessage);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(0, ex, ErrorMessage);
-                }
-            }
+            return MoveTo<BeginCertificateCreationState>();
         }
     }
 }

--- a/src/LettuceEncrypt/Internal/AcmeStates/ServerStartupState.cs
+++ b/src/LettuceEncrypt/Internal/AcmeStates/ServerStartupState.cs
@@ -1,0 +1,181 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+using LettuceEncrypt.Internal.IO;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace LettuceEncrypt.Internal.AcmeStates
+{
+    internal class ServerStartupState : AcmeState
+    {
+        private readonly ILogger<ServerStartupState> _logger;
+        private readonly IOptions<LettuceEncryptOptions> _options;
+        private readonly AcmeCertificateFactory _acmeCertificateFactory;
+        private readonly CertificateSelector _selector;
+        private readonly IEnumerable<ICertificateRepository> _certificateRepositories;
+        private readonly IClock _clock;
+
+        public ServerStartupState(
+            AcmeStateMachineContext context,
+            ILogger<ServerStartupState> logger,
+            IOptions<LettuceEncryptOptions> options,
+            AcmeCertificateFactory acmeCertificateFactory,
+            CertificateSelector selector,
+            IEnumerable<ICertificateRepository> certificateRepositories,
+            IClock clock)
+            : base(context)
+        {
+            _logger = logger;
+            _options = options;
+            _acmeCertificateFactory = acmeCertificateFactory;
+            _selector = selector;
+            _certificateRepositories = certificateRepositories;
+            _clock = clock;
+        }
+
+        private const string ErrorMessage = "Failed to create certificate";
+
+        public override async Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await LoadCerts(cancellationToken);
+            }
+            catch (AggregateException ex) when (ex.InnerException != null)
+            {
+                _logger.LogError(0, ex.InnerException, ErrorMessage);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(0, ex, ErrorMessage);
+            }
+
+            await MonitorRenewal(cancellationToken);
+            return this;
+        }
+
+        private async Task LoadCerts(CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var domainNames = _options.Value.DomainNames;
+            var hasCertForAllDomains = domainNames.All(_selector.HasCertForDomain);
+            if (hasCertForAllDomains)
+            {
+                _logger.LogDebug("Certificate for {domainNames} already found.", domainNames);
+                return;
+            }
+
+            await CreateCertificateAsync(domainNames, cancellationToken);
+        }
+
+        private async Task CreateCertificateAsync(string[] domainNames, CancellationToken cancellationToken)
+        {
+            var account = await _acmeCertificateFactory.GetOrCreateAccountAsync(cancellationToken);
+            _logger.LogInformation("Using account {accountId}", account.Id);
+
+            try
+            {
+                _logger.LogInformation("Creating certificate for {hostname}",
+                    string.Join(",", domainNames));
+
+                var cert = await _acmeCertificateFactory.CreateCertificateAsync(cancellationToken);
+
+                _logger.LogInformation("Created certificate {subjectName} ({thumbprint})",
+                    cert.Subject,
+                    cert.Thumbprint);
+
+                await SaveCertificateAsync(cert, cancellationToken);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(0, ex, "Failed to automatically create a certificate for {hostname}", domainNames);
+                throw;
+            }
+        }
+
+        private async Task SaveCertificateAsync(X509Certificate2 cert, CancellationToken cancellationToken)
+        {
+            _selector.Add(cert);
+
+            var saveTasks = new List<Task>
+            {
+                Task.Delay(TimeSpan.FromMinutes(5), cancellationToken)
+            };
+
+            var errors = new List<Exception>();
+            foreach (var repo in _certificateRepositories)
+            {
+                try
+                {
+                    saveTasks.Add(repo.SaveAsync(cert, cancellationToken));
+                }
+                catch (Exception ex)
+                {
+                    // synchronous saves may fail immediately
+                    errors.Add(ex);
+                }
+            }
+
+            await Task.WhenAll(saveTasks);
+
+            if (errors.Count > 0)
+            {
+                throw new AggregateException("Failed to save cert to repositories", errors);
+            }
+        }
+
+        private async Task MonitorRenewal(CancellationToken cancellationToken)
+        {
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                var checkPeriod = _options.Value.RenewalCheckPeriod;
+                var daysInAdvance = _options.Value.RenewDaysInAdvance;
+                if (!checkPeriod.HasValue || !daysInAdvance.HasValue)
+                {
+                    _logger.LogInformation("Automatic certificate renewal is not configured. Stopping {service}",
+                        nameof(AcmeCertificateLoader));
+                    return;
+                }
+
+                await Task.Delay(checkPeriod.Value, cancellationToken);
+
+                try
+                {
+                    var domainNames = _options.Value.DomainNames;
+                    if (_logger.IsEnabled(LogLevel.Debug))
+                    {
+                        _logger.LogDebug("Checking certificates' renewals for {hostname}",
+                            string.Join(", ", domainNames));
+                    }
+
+                    foreach (var domainName in domainNames)
+                    {
+                        if (!_selector.TryGet(domainName, out var cert)
+                            || cert == null
+                            || cert.NotAfter <= _clock.Now.DateTime + daysInAdvance.Value)
+                        {
+                            await CreateCertificateAsync(domainNames, cancellationToken);
+                            break;
+                        }
+                    }
+                }
+                catch (AggregateException ex) when (ex.InnerException != null)
+                {
+                    _logger.LogError(0, ex.InnerException, ErrorMessage);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(0, ex, ErrorMessage);
+                }
+            }
+        }
+    }
+}

--- a/src/LettuceEncrypt/LettuceEncryptServiceCollectionExtensions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptServiceCollectionExtensions.cs
@@ -79,7 +79,10 @@ namespace Microsoft.Extensions.DependencyInjection
             services.AddSingleton(TerminalState.Singleton);
 
             // States should always be transient
-            services.AddTransient<ServerStartupState>();
+            services
+                .AddTransient<ServerStartupState>()
+                .AddTransient<CheckForRenewalState>()
+                .AddTransient<BeginCertificateCreationState>();
 
             return new LettuceEncryptServiceBuilder(services);
         }

--- a/src/LettuceEncrypt/LettuceEncryptServiceCollectionExtensions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptServiceCollectionExtensions.cs
@@ -5,6 +5,7 @@ using System;
 using LettuceEncrypt;
 using LettuceEncrypt.Acme;
 using LettuceEncrypt.Internal;
+using LettuceEncrypt.Internal.AcmeStates;
 using LettuceEncrypt.Internal.IO;
 using McMaster.AspNetCore.Kestrel.Certificates;
 using Microsoft.AspNetCore.Hosting;
@@ -71,6 +72,14 @@ namespace Microsoft.Extensions.DependencyInjection
             });
 
             services.Configure(configure);
+
+            // The state machine should run in its own scope
+            services.AddScoped<AcmeStateMachineContext>();
+
+            services.AddSingleton(TerminalState.Singleton);
+
+            // States should always be transient
+            services.AddTransient<ServerStartupState>();
 
             return new LettuceEncryptServiceBuilder(services);
         }


### PR DESCRIPTION
The lifecycle of certificate generation is getting sufficiently complicated that I'm planning to refactor it using the state pattern. This lays the foundation and wraps the top of the loop in a single state. Splitting the code into smaller, more manageable states will come in later steps.