### PR TITLE
add support for .net core 3.1 when using UseLettuceEncrypt

### DIFF
--- a/src/LettuceEncrypt/LettuceEncryptKestrelHttpsOptionsExtensions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptKestrelHttpsOptionsExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Hosting
                 throw new InvalidOperationException(MissingServicesMessage);
             }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1
             var tlsResponder = applicationServices.GetService<TlsAlpnChallengeResponder>();
             if (tlsResponder is null)
             {
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Hosting
 #endif
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_0 || NETCOREAPP3_1
         internal static HttpsConnectionAdapterOptions UseLettuceEncrypt(
             this HttpsConnectionAdapterOptions httpsOptions,
             IServerCertificateSelector selector,


### PR DESCRIPTION
add support for .net core 3.1 when using UseLettuceEncrypt