### PR TITLE
Avoid issue with new KestrelServerImpl class in net5

### DIFF
--- a/src/LettuceEncrypt/Internal/AcmeCertificateLoader.cs
+++ b/src/LettuceEncrypt/Internal/AcmeCertificateLoader.cs
@@ -44,10 +44,9 @@ namespace LettuceEncrypt.Internal
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            var serverType = _server.GetType().FullName!;
-
-            if (!(serverType.StartsWith(nameof(KestrelServer))))
+            if (!(_server.GetType().Name.StartsWith(nameof(KestrelServer))))
             {
+                var serverType = _server.GetType().FullName!;
                 _logger.LogWarning(
                     "LettuceEncrypt can only be used with Kestrel and is not supported on {serverType} servers. Skipping certificate provisioning.",
                     serverType);

--- a/src/LettuceEncrypt/Internal/AcmeCertificateLoader.cs
+++ b/src/LettuceEncrypt/Internal/AcmeCertificateLoader.cs
@@ -44,9 +44,10 @@ namespace LettuceEncrypt.Internal
 
         protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            if (!(_server is KestrelServer))
+            var serverType = _server.GetType().FullName!;
+
+            if (!(serverType.StartsWith(nameof(KestrelServer))))
             {
-                var serverType = _server.GetType().FullName;
                 _logger.LogWarning(
                     "LettuceEncrypt can only be used with Kestrel and is not supported on {serverType} servers. Skipping certificate provisioning.",
                     serverType);

--- a/src/LettuceEncrypt/Internal/AcmeCertificateLoader.cs
+++ b/src/LettuceEncrypt/Internal/AcmeCertificateLoader.cs
@@ -46,7 +46,7 @@ namespace LettuceEncrypt.Internal
         {
             if (!(_server.GetType().Name.StartsWith(nameof(KestrelServer))))
             {
-                var serverType = _server.GetType().FullName!;
+                var serverType = _server.GetType().FullName;
                 _logger.LogWarning(
                     "LettuceEncrypt can only be used with Kestrel and is not supported on {serverType} servers. Skipping certificate provisioning.",
                     serverType);


### PR DESCRIPTION
Adjusts check for allowed server to avoid issue with new KestrelServerImpl class in net5.

Aims to solve initial issue raised in #146 but does not go so far as to add full net5 support.