### PR TITLE
cleanup: add dotnet-format to build script and CI check

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,9 +3,15 @@
   "isRoot": true,
   "tools": {
     "dotnet-reportgenerator-globaltool": {
-      "version": "4.4.0",
+      "version": "4.8.4",
       "commands": [
         "reportgenerator"
+      ]
+    },
+    "dotnet-format": {
+      "version": "4.1.131201",
+      "commands": [
+        "dotnet-format"
       ]
     }
   }

--- a/build.ps1
+++ b/build.ps1
@@ -32,7 +32,6 @@ if ($ci) {
     & dotnet --info
 }
 
-$isPr = $env:APPVEYOR_PULL_REQUEST_HEAD_COMMIT -or ($env:BUILD_REASON -eq 'PullRequest')
 if (-not (Test-Path variable:\IsCoreCLR)) {
     $IsWindows = $true
 }
@@ -42,6 +41,13 @@ $artifacts = "$PSScriptRoot/artifacts/"
 Remove-Item -Recurse $artifacts -ErrorAction Ignore
 
 exec dotnet tool restore
+
+[string[]] $formatArgs=@()
+if ($ci) {
+    $formatArgs += '--check'
+}
+
+exec dotnet tool run dotnet-format -- -v detailed @formatArgs
 exec dotnet build --configuration $Configuration '-warnaserror:CS1591' @MSBuildArgs
 exec dotnet pack --no-restore --no-build --configuration $Configuration -o $artifacts @MSBuildArgs
 

--- a/src/LettuceEncrypt/Internal/AcmeCertificateFactory.cs
+++ b/src/LettuceEncrypt/Internal/AcmeCertificateFactory.cs
@@ -100,7 +100,7 @@ namespace LettuceEncrypt.Internal
             var accountModel = new AccountModel
             {
                 Id = accountId,
-                EmailAddresses = new[] {options.EmailAddress},
+                EmailAddresses = new[] { options.EmailAddress },
                 PrivateKey = _acmeAccountKey.ToDer(),
             };
 
@@ -375,7 +375,7 @@ namespace LettuceEncrypt.Internal
             {
                 CommonName = commonName,
             };
-            var privateKey = KeyFactory.NewKey((Certes.KeyAlgorithm) _options.Value.KeyAlgorithm);
+            var privateKey = KeyFactory.NewKey((Certes.KeyAlgorithm)_options.Value.KeyAlgorithm);
             var acmeCert = await _client.GetCertificateAsync(csrInfo, privateKey, order);
 
             _logger.LogAcmeAction("NewCertificate");

--- a/src/LettuceEncrypt/Internal/AcmeStates/AcmeState.cs
+++ b/src/LettuceEncrypt/Internal/AcmeStates/AcmeState.cs
@@ -17,7 +17,7 @@ namespace LettuceEncrypt.Internal.AcmeStates
     {
         public static TerminalState Singleton { get; } = new TerminalState();
 
-        private TerminalState() {}
+        private TerminalState() { }
 
         public Task<IAcmeState> MoveNextAsync(CancellationToken cancellationToken)
         {

--- a/src/LettuceEncrypt/Internal/FileSystemAccountStore.cs
+++ b/src/LettuceEncrypt/Internal/FileSystemAccountStore.cs
@@ -43,7 +43,7 @@ namespace LettuceEncrypt.Internal
 
             foreach (var jsonFile in _accountDir.GetFiles("*.json"))
             {
-                _logger.LogTrace("Parsing {path} for account info",jsonFile);
+                _logger.LogTrace("Parsing {path} for account info", jsonFile);
 
                 var accountModel = await Deserialize(jsonFile, cancellationToken);
                 if (accountModel != null)

--- a/test/LettuceEncrypt.Azure.UnitTests/AzureKeyVaultAccountStoreTests.cs
+++ b/test/LettuceEncrypt.Azure.UnitTests/AzureKeyVaultAccountStoreTests.cs
@@ -40,7 +40,7 @@ namespace LettuceEncrypt.Azure.UnitTests
             var accountModel = new AccountModel
             {
                 Id = 1234,
-                EmailAddresses = new[] {"test@example.com"},
+                EmailAddresses = new[] { "test@example.com" },
                 PrivateKey = KeyFactory.NewKey(Certes.KeyAlgorithm.ES512).ToDer(),
             };
 

--- a/test/LettuceEncrypt.Azure.UnitTests/AzureKeyVaultTests.cs
+++ b/test/LettuceEncrypt.Azure.UnitTests/AzureKeyVaultTests.cs
@@ -3,9 +3,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Security.KeyVault.Certificates;
 using Azure.Security.KeyVault.Secrets;
-using LettuceEncrypt.UnitTests;
 using LettuceEncrypt;
 using LettuceEncrypt.Azure.Internal;
+using LettuceEncrypt.UnitTests;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Hosting.Internal;
@@ -76,7 +76,7 @@ namespace LettuceEncrypt.Azure.UnitTests
             certClientFactory.Setup(c => c.Create()).Returns(certClient.Object);
             var options = Options.Create(new LettuceEncryptOptions());
 
-            options.Value.DomainNames = new[] {Domain1, Domain2};
+            options.Value.DomainNames = new[] { Domain1, Domain2 };
 
             var repository = new AzureKeyVaultCertificateRepository(
                 certClientFactory.Object,
@@ -106,7 +106,7 @@ namespace LettuceEncrypt.Azure.UnitTests
             secretClientFactory.Setup(c => c.Create()).Returns(secretClient.Object);
             var options = Options.Create(new LettuceEncryptOptions());
 
-            options.Value.DomainNames = new[] {Domain1, Domain2};
+            options.Value.DomainNames = new[] { Domain1, Domain2 };
 
             var repository = new AzureKeyVaultCertificateRepository(
                 Mock.Of<ICertificateClientFactory>(),

--- a/test/LettuceEncrypt.UnitTests/FileSystemAccountStoreTests.cs
+++ b/test/LettuceEncrypt.UnitTests/FileSystemAccountStoreTests.cs
@@ -57,7 +57,7 @@ namespace LettuceEncrypt.UnitTests
             var account = new AccountModel
             {
                 Id = 1,
-                EmailAddresses = new[] {"test@test.com"},
+                EmailAddresses = new[] { "test@test.com" },
                 PrivateKey = bytes,
             };
 

--- a/test/LettuceEncrypt.UnitTests/KestrelOptionsSetupTests.cs
+++ b/test/LettuceEncrypt.UnitTests/KestrelOptionsSetupTests.cs
@@ -25,7 +25,7 @@ namespace LettuceEncrypt.UnitTests
                 typeof(KestrelServerOptions).GetProperty("HttpsDefaults",
                     BindingFlags.Instance | BindingFlags.NonPublic);
             var httpsDefaultsFunc =
-                (Action<HttpsConnectionAdapterOptions>) httpsDefaultsProp.GetMethod.Invoke(kestrelOptions,
+                (Action<HttpsConnectionAdapterOptions>)httpsDefaultsProp.GetMethod.Invoke(kestrelOptions,
                     Array.Empty<object>());
             var httpsDefaults = new HttpsConnectionAdapterOptions();
 

--- a/test/LettuceEncrypt.UnitTests/StartupCertificateLoaderTests.cs
+++ b/test/LettuceEncrypt.UnitTests/StartupCertificateLoaderTests.cs
@@ -17,7 +17,7 @@ namespace LettuceEncrypt.UnitTests
         public async Task ItLoadsAllCertsIntoSelector()
         {
             var testCert = new X509Certificate2();
-            IEnumerable<X509Certificate2> certs = new[] {testCert};
+            IEnumerable<X509Certificate2> certs = new[] { testCert };
 
             var selector = new Mock<CertificateSelector>(
                 Options.Create(new LettuceEncryptOptions()),
@@ -31,7 +31,7 @@ namespace LettuceEncrypt.UnitTests
             var source2 = CreateCertSource(certs);
 
             var startupLoader = new StartupCertificateLoader(
-                new[] {source1.Object, source2.Object},
+                new[] { source1.Object, source2.Object },
                 selector.Object);
 
             await startupLoader.StartAsync(default);

--- a/test/LettuceEncrypt.UnitTests/X509CertStoreTests.cs
+++ b/test/LettuceEncrypt.UnitTests/X509CertStoreTests.cs
@@ -40,7 +40,7 @@ namespace LettuceEncrypt.UnitTests
         public async Task ItFindsCertByCommonNameAsync()
         {
             var commonName = "x509store.read.test.natemcmaster.com";
-            _options.DomainNames = new[] {commonName};
+            _options.DomainNames = new[] { commonName };
             using var x509Store = new X509Store(StoreName.My, StoreLocation.CurrentUser);
             x509Store.Open(OpenFlags.ReadWrite);
             var testCert = CreateTestCert(commonName);
@@ -97,7 +97,7 @@ namespace LettuceEncrypt.UnitTests
         public async Task ItReturnsEmptyWhenCantFindCertAsync()
         {
             var commonName = "notfound.test.natemcmaster.com";
-            _options.DomainNames = new[] {commonName};
+            _options.DomainNames = new[] { commonName };
             var certs = await _certStore.GetCertificatesAsync(default);
             Assert.Empty(certs);
         }


### PR DESCRIPTION
Add dotnet-format to build.ps1 and enforce in CI. Helps to reduce unnecessary format change diffs and review feedback loops on trivial matters like formatting.