### PR TITLE
Update target framework from .NET Core 3.0 to 3.1

### DIFF
--- a/src/Kestrel.Certificates/McMaster.AspNetCore.Kestrel.Certificates.csproj
+++ b/src/Kestrel.Certificates/McMaster.AspNetCore.Kestrel.Certificates.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
@@ -11,7 +11,7 @@
     <PackageVersion Condition="'$(IncludePreReleaseLabelInPackageVersion)' == 'true'">$(PackageVersion)-$(VersionSuffix)</PackageVersion>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/LettuceEncrypt.Azure/LettuceEncrypt.Azure.csproj
+++ b/src/LettuceEncrypt.Azure/LettuceEncrypt.Azure.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netcoreapp3.1</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
@@ -12,7 +12,7 @@ See https://nuget.org/packages/LettuceEncrypt for more details.
     </PackageDescription>
   </PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <DefineConstants>$(DefineConstants);FEATURE_VALIDATE_DATA_ANNOTATIONS</DefineConstants>
   </PropertyGroup>
 

--- a/src/LettuceEncrypt/Internal/CertificateSelector.cs
+++ b/src/LettuceEncrypt/Internal/CertificateSelector.cs
@@ -76,7 +76,7 @@ namespace LettuceEncrypt.Internal
 
         public X509Certificate2? Select(ConnectionContext context, string? domainName)
         {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             if (_challengeCerts.Count > 0)
             {
                 // var sslStream = context.Features.Get<SslStream>();

--- a/src/LettuceEncrypt/Internal/KestrelOptionsSetup.cs
+++ b/src/LettuceEncrypt/Internal/KestrelOptionsSetup.cs
@@ -24,7 +24,7 @@ namespace LettuceEncrypt.Internal
         {
             options.ConfigureHttpsDefaults(o =>
             {
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
                 o.UseLettuceEncrypt(_certificateSelector, _tlsAlpnChallengeResponder);
 #elif NETSTANDARD2_0
                 o.UseServerCertificateSelector(_certificateSelector);

--- a/src/LettuceEncrypt/Internal/TlsAlpnChallengeResponder.cs
+++ b/src/LettuceEncrypt/Internal/TlsAlpnChallengeResponder.cs
@@ -24,7 +24,7 @@ namespace LettuceEncrypt.Internal
         // See RFC8737 section 6.1
         private static readonly Oid s_acmeExtensionOid = new Oid("1.3.6.1.5.5.7.1.31");
         private const string ProtocolName = "acme-tls/1";
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         private static readonly SslApplicationProtocol s_acmeTlsProtocol = new SslApplicationProtocol(ProtocolName);
 #endif
         private readonly IClock _clock;
@@ -51,7 +51,7 @@ namespace LettuceEncrypt.Internal
             throw new PlatformNotSupportedException();
         }
 
-#elif NETCOREAPP3_0
+#elif NETCOREAPP3_1
         public bool IsEnabled => true;
 
         public void OnSslAuthenticate(ConnectionContext context, SslServerAuthenticationOptions options)

--- a/src/LettuceEncrypt/LettuceEncrypt.csproj
+++ b/src/LettuceEncrypt/LettuceEncrypt.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;netstandard2.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Nullable>enable</Nullable>
     <IsPackable>true</IsPackable>
@@ -21,7 +21,7 @@ This only works with Kestrel, which is the default server configuration for ASP.
     <PackageReference Include="Certes" Version="2.3.4" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/LettuceEncrypt/LettuceEncryptKestrelHttpsOptionsExtensions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptKestrelHttpsOptionsExtensions.cs
@@ -39,7 +39,7 @@ namespace Microsoft.AspNetCore.Hosting
                 throw new InvalidOperationException(MissingServicesMessage);
             }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
             var tlsResponder = applicationServices.GetService<TlsAlpnChallengeResponder>();
             if (tlsResponder is null)
             {
@@ -55,7 +55,7 @@ namespace Microsoft.AspNetCore.Hosting
 #endif
         }
 
-#if NETCOREAPP3_0
+#if NETCOREAPP3_1
         internal static HttpsConnectionAdapterOptions UseLettuceEncrypt(
             this HttpsConnectionAdapterOptions httpsOptions,
             IServerCertificateSelector selector,


### PR DESCRIPTION
https://dotnet.microsoft.com/platform/support/policy/dotnet-core

Support for .NET Core 3.0 ended in 2020. I am dropping support for it in this package as well.

