### PR TITLE
Add API to select which types of ACME challenges will be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,31 @@ class MyAccountStore: IAccountStore
 }
 ```
 
+
+### Changing which challenge types are used
+
+The ACME protocol supports multiple methods for proving you own a DNS name called "challenge types".
+If you wish to manually select which challenge types are used, set the "AllowedChallengeTypes" method.
+The default value is "Any", which means this library will exhaust all supported challenge types before
+giving up.
+
+Current supported values:
+* `Http01` - The HTTP-01 challenge, which uses a well-known URL on the server and a HTTP request/response.
+* `TlsAlpn01` - The TLS-ALPN-01 challenge, which uses an auto-generated, ephemeral certificate in the TLS handshake.
+* `Any` - _(default)_ - use HTTP-01 and/or TLS-ALPN-01
+
+Tip: if you wish to set multiple method types and are use the "appsettings.json" approach, provide a comma-seperated list.
+
+
+```json
+{
+    "LettuceEncrypt": {
+        "AllowedChallengeTypes": "Http01, TlsAlpn01"
+    }
+}
+```
+
+
 ## Testing in development
 
 See the [developer docs](./test/Integration/) for details on how to test in a non-production environment.

--- a/src/LettuceEncrypt/Acme/ChallengeType.cs
+++ b/src/LettuceEncrypt/Acme/ChallengeType.cs
@@ -1,0 +1,32 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+
+namespace LettuceEncrypt.Acme
+{
+    /// <summary>
+    /// An enumeration that represents the various kinds of challenges in the ACME protocol.
+    /// See https://letsencrypt.org/docs/challenge-types/.
+    /// </summary>
+    [Flags]
+    public enum ChallengeType
+    {
+        /// <summary>
+        /// The HTTP-01 challenge, which uses a well-known URL on the server and a HTTP request/response.
+        /// See https://letsencrypt.org/docs/challenge-types/#http-01-challenge
+        /// </summary>
+        Http01 = 1 << 0,
+
+        /// <summary>
+        /// The TLS-ALPN-01 challenge, which uses an auto-generated, ephemeral certificate in the TLS handshake.
+        /// See https://letsencrypt.org/docs/challenge-types/#tls-alpn-01
+        /// </summary>
+        TlsAlpn01 = 1 << 1,
+
+        /// <summary>
+        /// A special flag which represents all known challenge types.
+        /// </summary>
+        Any = 0xFFFF,
+    }
+}

--- a/src/LettuceEncrypt/Internal/TlsAlpnChallengeResponder.cs
+++ b/src/LettuceEncrypt/Internal/TlsAlpnChallengeResponder.cs
@@ -8,9 +8,11 @@ using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading;
+using LettuceEncrypt.Acme;
 using LettuceEncrypt.Internal.IO;
 using Microsoft.AspNetCore.Connections;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using Org.BouncyCastle.Asn1;
 
 namespace LettuceEncrypt.Internal
@@ -29,14 +31,17 @@ namespace LettuceEncrypt.Internal
 #endif
         private readonly IClock _clock;
         private readonly ILogger<TlsAlpnChallengeResponder> _logger;
+        private readonly IOptions<LettuceEncryptOptions> _options;
         private readonly CertificateSelector _certificateSelector;
         private int _openChallenges = 0;
 
         public TlsAlpnChallengeResponder(
+            IOptions<LettuceEncryptOptions> options,
             CertificateSelector certificateSelector,
             IClock clock,
             ILogger<TlsAlpnChallengeResponder> logger)
         {
+            _options = options ?? throw new ArgumentNullException(nameof(options));
             _certificateSelector = certificateSelector ?? throw new ArgumentNullException(nameof(certificateSelector));
             _clock = clock ?? throw new ArgumentNullException(nameof(clock));
             _logger = logger ?? throw new ArgumentNullException(nameof(logger));
@@ -52,7 +57,7 @@ namespace LettuceEncrypt.Internal
         }
 
 #elif NETCOREAPP3_1
-        public bool IsEnabled => true;
+        public bool IsEnabled => _options.Value.AllowedChallengeTypes.HasFlag(ChallengeType.TlsAlpn01);
 
         public void OnSslAuthenticate(ConnectionContext context, SslServerAuthenticationOptions options)
         {

--- a/src/LettuceEncrypt/LettuceEncryptOptions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptOptions.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Security.Cryptography.X509Certificates;
+using LettuceEncrypt.Acme;
 
 namespace LettuceEncrypt
 {
@@ -71,5 +72,11 @@ namespace LettuceEncrypt
         /// The asymmetric algorithm used for generating a private key for certificates: RS256, ES256, ES384, ES512
         /// </summary>
         public KeyAlgorithm KeyAlgorithm { get; set; } = KeyAlgorithm.ES256;
+
+        /// <summary>
+        /// Specifies which kinds of ACME challenges LettuceEncrypt can use to verify domain ownership.
+        /// Defaults to <see cref="ChallengeType.Any"/>.
+        /// </summary>
+        public ChallengeType AllowedChallengeTypes { get; set; } = ChallengeType.Any;
     }
 }

--- a/src/LettuceEncrypt/PublicAPI.Unshipped.txt
+++ b/src/LettuceEncrypt/PublicAPI.Unshipped.txt
@@ -1,5 +1,11 @@
 #nullable enable
+LettuceEncrypt.Acme.ChallengeType
+LettuceEncrypt.Acme.ChallengeType.Http01 = 1 -> LettuceEncrypt.Acme.ChallengeType
+LettuceEncrypt.Acme.ChallengeType.TlsAlpn01 = 2 -> LettuceEncrypt.Acme.ChallengeType
+LettuceEncrypt.Acme.ChallengeType.Any = 65535 -> LettuceEncrypt.Acme.ChallengeType
 LettuceEncrypt.Acme.ICertificateAuthorityConfiguration
 LettuceEncrypt.Acme.ICertificateAuthorityConfiguration.AcmeDirectoryUri.get -> System.Uri!
+LettuceEncrypt.LettuceEncryptOptions.AllowedChallengeTypes.get -> LettuceEncrypt.Acme.ChallengeType
+LettuceEncrypt.LettuceEncryptOptions.AllowedChallengeTypes.set -> void
 Microsoft.AspNetCore.Hosting.LettuceEncryptKestrelHttpsOptionsExtensions
 static Microsoft.AspNetCore.Hosting.LettuceEncryptKestrelHttpsOptionsExtensions.UseLettuceEncrypt(this Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions! httpsOptions, System.IServiceProvider! applicationServices) -> Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions!

--- a/test/LettuceEncrypt.UnitTests/ChallengeTypeTests.cs
+++ b/test/LettuceEncrypt.UnitTests/ChallengeTypeTests.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using LettuceEncrypt.Acme;
+using Xunit;
+
+namespace LettuceEncrypt.UnitTests
+{
+    public class ChallengeTypeTests
+    {
+        [Fact]
+        public void AnyIsAlwaysTrue()
+        {
+            Assert.True(ChallengeType.Any.HasFlag(ChallengeType.Http01));
+            Assert.True(ChallengeType.Any.HasFlag(ChallengeType.TlsAlpn01));
+            Assert.True(ChallengeType.Any.HasFlag(ChallengeType.Any));
+        }
+    }
+}


### PR DESCRIPTION
The ACME protocol supports multiple methods for proving you own a DNS name called "challenge types".
If you wish to manually select which challenge types are used, set the "AllowedChallengeTypes" method.
The default value is "Any", which means this library will exhaust all supported challenge types before
giving up.

Current supported values:
* `Http01` - The HTTP-01 challenge, which uses a well-known URL on the server and a HTTP request/response.
* `TlsAlpn01` - The TLS-ALPN-01 challenge, which uses an auto-generated, ephemeral certificate in the TLS handshake.
* `Any` - _(default)_ - use HTTP-01 and/or TLS-ALPN-01

Tip: if you wish to set multiple method types and are use the "appsettings.json" approach, provide a comma-seperated list.


```json
{
    "LettuceEncrypt": {
        "AllowedChallengeTypes": "Http01, TlsAlpn01"
    }
}
```