### PR TITLE
If multiple validation methods are enabled, run serially

### DIFF
--- a/LettuceEncrypt.sln
+++ b/LettuceEncrypt.sln
@@ -24,6 +24,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "files", "files", "{A92C89F3
 		CONTRIBUTING.md = CONTRIBUTING.md
 		Directory.Build.props = Directory.Build.props
 		Directory.Build.targets = Directory.Build.targets
+		.config\dotnet-tools.json = .config\dotnet-tools.json
 		README.md = README.md
 	EndProjectSection
 EndProject
@@ -33,7 +34,7 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LettuceEncrypt.Azure.UnitTe
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "KeyVault", "samples\KeyVault\KeyVault.csproj", "{6143D097-6983-4A29-9DAE-1DD0EBC900D2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "McMaster.AspNetCore.Kestrel.Certificates", "src\Kestrel.Certificates\McMaster.AspNetCore.Kestrel.Certificates.csproj", "{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "McMaster.AspNetCore.Kestrel.Certificates", "src\Kestrel.Certificates\McMaster.AspNetCore.Kestrel.Certificates.csproj", "{8131AFC9-ED23-4A3A-9D38-5200E4D8B168}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/LettuceEncrypt/Internal/DomainOwnershipValidator.cs
+++ b/src/LettuceEncrypt/Internal/DomainOwnershipValidator.cs
@@ -1,0 +1,102 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Certes.Acme;
+using Certes.Acme.Resource;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+#if NETSTANDARD2_0
+using IHostApplicationLifetime = Microsoft.Extensions.Hosting.IApplicationLifetime;
+#endif
+
+namespace LettuceEncrypt.Internal
+{
+    internal abstract class DomainOwnershipValidator
+    {
+        protected readonly AcmeClient _client;
+        protected readonly ILogger _logger;
+        protected readonly string _domainName;
+        protected readonly TaskCompletionSource<object?> _appStarted = new();
+
+        protected DomainOwnershipValidator(IHostApplicationLifetime appLifetime, AcmeClient client, ILogger logger, string domainName)
+        {
+            _client = client;
+            _logger = logger;
+            _domainName = domainName;
+
+            appLifetime.ApplicationStarted.Register(() => _appStarted.TrySetResult(null));
+            if (appLifetime.ApplicationStarted.IsCancellationRequested)
+            {
+                _appStarted.TrySetResult(null);
+            }
+        }
+
+        public abstract Task ValidateOwnershipAsync(IAuthorizationContext authzContext, CancellationToken cancellationToken);
+
+        private async Task WaitForChallengeResultAsync(IAuthorizationContext authorizationContext, CancellationToken cancellationToken)
+        {
+            var retries = 60;
+            var delay = TimeSpan.FromSeconds(2);
+
+            while (retries > 0)
+            {
+                retries--;
+
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var authorization = await _client.GetAuthorizationAsync(authorizationContext);
+
+                _logger.LogAcmeAction("GetAuthorization");
+
+                switch (authorization.Status)
+                {
+                    case AuthorizationStatus.Valid:
+                        return;
+                    case AuthorizationStatus.Pending:
+                        await Task.Delay(delay, cancellationToken);
+                        continue;
+                    case AuthorizationStatus.Invalid:
+                        throw InvalidAuthorizationError(authorization);
+                    case AuthorizationStatus.Revoked:
+                        throw new InvalidOperationException(
+                            $"The authorization to verify domainName '{_domainName}' has been revoked.");
+                    case AuthorizationStatus.Expired:
+                        throw new InvalidOperationException(
+                            $"The authorization to verify domainName '{_domainName}' has expired.");
+                    case AuthorizationStatus.Deactivated:
+                    default:
+                        throw new ArgumentOutOfRangeException("authorization",
+                            "Unexpected response from server while validating domain ownership.");
+                }
+            }
+
+            throw new TimeoutException("Timed out waiting for domain ownership validation.");
+        }
+
+        private Exception InvalidAuthorizationError(Authorization authorization)
+        {
+            var reason = "unknown";
+            var domainName = authorization.Identifier.Value;
+            try
+            {
+                var errors = authorization.Challenges.Where(a => a.Error != null).Select(a => a.Error)
+                    .Select(error => $"{error.Type}: {error.Detail}, Code = {error.Status}");
+                reason = string.Join("; ", errors);
+            }
+            catch
+            {
+                _logger.LogTrace("Could not determine reason why validation failed. Response: {resp}", authorization);
+            }
+
+            _logger.LogError("Failed to validate ownership of domainName '{domainName}'. Reason: {reason}", domainName,
+                reason);
+
+            return new InvalidOperationException($"Failed to validate ownership of domainName '{domainName}'");
+        }
+    }
+}

--- a/src/LettuceEncrypt/Internal/Http01DomainValidator.cs
+++ b/src/LettuceEncrypt/Internal/Http01DomainValidator.cs
@@ -1,0 +1,62 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Certes.Acme;
+using Certes.Acme.Resource;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+#if NETSTANDARD2_0
+using IHostApplicationLifetime = Microsoft.Extensions.Hosting.IApplicationLifetime;
+#endif
+
+namespace LettuceEncrypt.Internal
+{
+    internal class Http01DomainValidator : DomainOwnershipValidator
+    {
+        private readonly IHttpChallengeResponseStore _challengeStore;
+
+        public Http01DomainValidator(IHttpChallengeResponseStore challengeStore,
+            IHostApplicationLifetime appLifetime,
+            AcmeClient client, ILogger logger, string domainName) : base(appLifetime, client, logger, domainName)
+        {
+            _challengeStore = challengeStore;
+        }
+
+        public override async Task ValidateOwnershipAsync(IAuthorizationContext authzContext, CancellationToken cancellationToken)
+        {
+            await PrepareHttpChallengeResponseAsync(authzContext, cancellationToken);
+            await ValidateOwnershipAsync(authzContext, cancellationToken);
+        }
+
+        private async Task PrepareHttpChallengeResponseAsync(
+            IAuthorizationContext authorizationContext,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            if (_client == null)
+            {
+                throw new InvalidOperationException();
+            }
+
+            var httpChallenge = await _client.CreateChallengeAsync(authorizationContext, ChallengeTypes.Http01);
+            if (httpChallenge == null)
+            {
+                throw new InvalidOperationException(
+                    $"Did not receive challenge information for challenge type {ChallengeTypes.Http01}");
+            }
+
+            var keyAuth = httpChallenge.KeyAuthz;
+            _challengeStore.AddChallengeResponse(httpChallenge.Token, keyAuth);
+
+            _logger.LogTrace("Waiting for server to start accepting HTTP requests");
+            await _appStarted.Task;
+
+            _logger.LogTrace("Requesting server to validate HTTP challenge");
+            await _client.ValidateChallengeAsync(httpChallenge);
+        }
+    }
+}

--- a/src/LettuceEncrypt/Internal/TlsAlpn01DomainValidator.cs
+++ b/src/LettuceEncrypt/Internal/TlsAlpn01DomainValidator.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Threading;
+using System.Threading.Tasks;
+using Certes.Acme;
+using Certes.Acme.Resource;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+#if NETSTANDARD2_0
+using IHostApplicationLifetime = Microsoft.Extensions.Hosting.IApplicationLifetime;
+#endif
+
+namespace LettuceEncrypt.Internal
+{
+    internal class TlsAlpn01DomainValidator : DomainOwnershipValidator
+    {
+        private readonly TlsAlpnChallengeResponder _tlsAlpnChallengeResponder;
+
+        public TlsAlpn01DomainValidator(TlsAlpnChallengeResponder tlsAlpnChallengeResponder,
+            IHostApplicationLifetime appLifetime,
+            AcmeClient client, ILogger logger, string domainName) : base(appLifetime, client, logger, domainName)
+        {
+            _tlsAlpnChallengeResponder = tlsAlpnChallengeResponder;
+        }
+
+        public override async Task ValidateOwnershipAsync(IAuthorizationContext authzContext, CancellationToken cancellationToken)
+        {
+            try
+            {
+                await PrepareTlsAlpnChallengeResponseAsync(authzContext, _domainName, cancellationToken);
+                await ValidateOwnershipAsync(authzContext, cancellationToken);
+            }
+            finally
+            {
+                // cleanup after authorization is done to skip unnecessary cert lookup on all incoming SSL connections
+                _tlsAlpnChallengeResponder.DiscardChallenge(_domainName);
+            }
+        }
+
+        private async Task PrepareTlsAlpnChallengeResponseAsync(
+            IAuthorizationContext authorizationContext,
+            string domainName,
+            CancellationToken cancellationToken)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+
+            var tlsAlpnChallenge = await _client.CreateChallengeAsync(authorizationContext, ChallengeTypes.TlsAlpn01);
+
+            _tlsAlpnChallengeResponder.PrepareChallengeCert(domainName, tlsAlpnChallenge.KeyAuthz);
+
+            _logger.LogTrace("Waiting for server to start accepting HTTP requests");
+            await _appStarted.Task;
+
+            _logger.LogTrace("Requesting server to validate TLS/ALPN challenge");
+            await _client.ValidateChallengeAsync(tlsAlpnChallenge);
+        }
+    }
+}


### PR DESCRIPTION
One of the more common issues reported is failures in validation of the domain name. In re-reading the spec for ACME, it seems that requesting validation for multiple challenge types in parallel may have an undefined behavior.

This refactor changes LettuceEncrypt to try TLS-ALPN-01 first and then HTTP-01 validations (if enabled). TLS-ALPN-01 is given priority first since there seem to be some cases in which Kestrel HTTPS redirection interferes with HTTP-01. TLS-ALPN-01 should solve that.

Closes https://github.com/natemcmaster/LettuceEncrypt/issues/65
Closes https://github.com/natemcmaster/LettuceEncrypt/issues/141
Closes https://github.com/natemcmaster/LettuceEncrypt/issues/158