### PR TITLE
Optimize cert loading/rewewal checks on server startup

### DIFF
--- a/src/LettuceEncrypt/Internal/AcmeStates/CheckForRenewalState.cs
+++ b/src/LettuceEncrypt/Internal/AcmeStates/CheckForRenewalState.cs
@@ -42,8 +42,6 @@ namespace LettuceEncrypt.Internal.AcmeStates
                     return MoveTo<TerminalState>();
                 }
 
-                await Task.Delay(checkPeriod.Value, cancellationToken);
-
                 var domainNames = _options.Value.DomainNames;
                 if (_logger.IsEnabled(LogLevel.Debug))
                 {
@@ -60,6 +58,8 @@ namespace LettuceEncrypt.Internal.AcmeStates
                         return MoveTo<BeginCertificateCreationState>();
                     }
                 }
+
+                await Task.Delay(checkPeriod.Value, cancellationToken);
             }
 
             return MoveTo<TerminalState>();

--- a/src/LettuceEncrypt/Internal/StartupCertificateLoader.cs
+++ b/src/LettuceEncrypt/Internal/StartupCertificateLoader.cs
@@ -2,6 +2,8 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Hosting;
@@ -23,14 +25,17 @@ namespace LettuceEncrypt.Internal
 
         public async Task StartAsync(CancellationToken cancellationToken)
         {
+            var allCerts = new List<X509Certificate2>();
             foreach (var certSource in _certSources)
             {
                 var certs = await certSource.GetCertificatesAsync(cancellationToken);
+                allCerts.AddRange(certs);
+            }
 
-                foreach (var cert in certs)
-                {
-                    _selector.Add(cert);
-                }
+            // Add newer certificates first. This avoid potentially unnecessary cert validations on older certificates
+            foreach (var cert in allCerts.OrderByDescending(c => c.NotAfter))
+            {
+                _selector.Add(cert);
             }
         }
 

--- a/src/LettuceEncrypt/releasenotes.props
+++ b/src/LettuceEncrypt/releasenotes.props
@@ -17,6 +17,7 @@ Other:
 Fixes in patch 1.1.1:
  * Fix infinite loop waiting for verification of domain ownership
  * Check for certificates that new renewal immediately on server startup instead of waiting 24 hours
+ * Optimize loading intermediate certificate change and reduce unnecessary warnings about invalid certs
     </PackageReleaseNotes>
     <PackageReleaseNotes Condition="'$(VersionPrefix)' == '1.0.1'">
 * Fix bug in detecting Kestrel in .NET 5

--- a/src/LettuceEncrypt/releasenotes.props
+++ b/src/LettuceEncrypt/releasenotes.props
@@ -14,8 +14,9 @@ Bug fixes:
 Other:
  * Update package to target .NET Core 3.1 as 3.0 is no longer supported by Microsoft
 
-Bug patch 1.1.1:
+Fixes in patch 1.1.1:
  * Fix infinite loop waiting for verification of domain ownership
+ * Check for certificates that new renewal immediately on server startup instead of waiting 24 hours
     </PackageReleaseNotes>
     <PackageReleaseNotes Condition="'$(VersionPrefix)' == '1.0.1'">
 * Fix bug in detecting Kestrel in .NET 5

--- a/test/LettuceEncrypt.UnitTests/StartupCertificateLoaderTests.cs
+++ b/test/LettuceEncrypt.UnitTests/StartupCertificateLoaderTests.cs
@@ -18,7 +18,7 @@ namespace LettuceEncrypt.UnitTests
         [Fact]
         public async Task ItLoadsAllCertsIntoSelector()
         {
-            var testCert = new X509Certificate2();
+            var testCert = TestUtils.CreateTestCert("test1.natemcmaster.com");
             IEnumerable<X509Certificate2> certs = new[] { testCert };
 
             var selector = new Mock<CertificateSelector>(


### PR DESCRIPTION
Fixes
* check if certificate needs renewal immediately on startup instead waiting 24 hours
* Optimize loading intermediate certificate change and reduce unnecessary warnings about invalid certs