### PR TITLE
Support additional issuers for generated certificates

### DIFF
--- a/src/LettuceEncrypt/IAdditionalIssuersSource.cs
+++ b/src/LettuceEncrypt/IAdditionalIssuersSource.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System.Collections.Generic;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace LettuceEncrypt
+{
+    /// <summary>
+    /// Defines a source for certificates that will be accepted as issuers for generated certificates.
+    /// </summary>
+    public interface IAdditionalIssuersSource
+    {
+
+        /// <summary>
+        /// Gets available a collection of certificates that will be accepted as issuers for generated certificates.
+        /// </summary>
+        /// <param name="cancellationToken">A cancellation token.</param>
+        /// <returns>A collection of certificates</returns>
+        Task<IEnumerable<X509Certificate2>> GetAdditionalIssuersAsync(CancellationToken cancellationToken);
+    }
+}

--- a/src/LettuceEncrypt/Internal/AcmeCertificateFactory.cs
+++ b/src/LettuceEncrypt/Internal/AcmeCertificateFactory.cs
@@ -300,8 +300,8 @@ namespace LettuceEncrypt.Internal
 
             var pfxBuilder = acmeCert.ToPfx(privateKey);
 
-            
-            foreach(var additionalIssuersSource in _additionalIssuersSources)
+
+            foreach (var additionalIssuersSource in _additionalIssuersSources)
             {
                 var additionalIssuers = await additionalIssuersSource.GetAdditionalIssuersAsync(cancellationToken);
                 foreach (var cert in additionalIssuers)

--- a/src/LettuceEncrypt/Internal/AcmeCertificateFactory.cs
+++ b/src/LettuceEncrypt/Internal/AcmeCertificateFactory.cs
@@ -296,6 +296,17 @@ namespace LettuceEncrypt.Internal
             _logger.LogAcmeAction("NewCertificate");
 
             var pfxBuilder = acmeCert.ToPfx(privateKey);
+
+            var additionalIssuers = _options.Value.AdditionalIssuers;
+
+            if(additionalIssuers != null)
+            {
+                foreach(var cert in additionalIssuers)
+                {
+                    pfxBuilder.AddIssuer(cert.RawData);
+                }
+            }
+
             var pfx = pfxBuilder.Build("HTTPS Cert - " + _options.Value.DomainNames, string.Empty);
             return new X509Certificate2(pfx, string.Empty, X509KeyStorageFlags.Exportable);
         }

--- a/src/LettuceEncrypt/LettuceEncryptOptions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptOptions.cs
@@ -79,13 +79,5 @@ namespace LettuceEncrypt
         /// </summary>
         public ChallengeType AllowedChallengeTypes { get; set; } = ChallengeType.Any;
 
-
-        /// <summary>
-        /// Additional certificates that are accepted as issuers for the created issuers.
-        /// <para>
-        /// This can be null if there are no AdditionalIssuers
-        /// </para>
-        /// </summary>
-        public X509Certificate2Collection? AdditionalIssuers { get; set; }
     }
 }

--- a/src/LettuceEncrypt/LettuceEncryptOptions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptOptions.cs
@@ -78,5 +78,14 @@ namespace LettuceEncrypt
         /// Defaults to <see cref="ChallengeType.Any"/>.
         /// </summary>
         public ChallengeType AllowedChallengeTypes { get; set; } = ChallengeType.Any;
+
+
+        /// <summary>
+        /// Additional certificates that are accepted as issuers for the created issuers.
+        /// <para>
+        /// This can be null if there are no AdditionalIssuers
+        /// </para>
+        /// </summary>
+        public X509Certificate2Collection? AdditionalIssuers { get; set; }
     }
 }

--- a/src/LettuceEncrypt/PublicAPI.Unshipped.txt
+++ b/src/LettuceEncrypt/PublicAPI.Unshipped.txt
@@ -1,3 +1,3 @@
 #nullable enable
-LettuceEncrypt.LettuceEncryptOptions.AdditionalIssuers.get -> System.Security.Cryptography.X509Certificates.X509Certificate2Collection?
-LettuceEncrypt.LettuceEncryptOptions.AdditionalIssuers.set -> void
+LettuceEncrypt.IAdditionalIssuersSource
+LettuceEncrypt.IAdditionalIssuersSource.GetAdditionalIssuersAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<System.Collections.Generic.IEnumerable<System.Security.Cryptography.X509Certificates.X509Certificate2!>!>!

--- a/src/LettuceEncrypt/PublicAPI.Unshipped.txt
+++ b/src/LettuceEncrypt/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+LettuceEncrypt.LettuceEncryptOptions.AdditionalIssuers.get -> System.Security.Cryptography.X509Certificates.X509Certificate2Collection?
+LettuceEncrypt.LettuceEncryptOptions.AdditionalIssuers.set -> void


### PR DESCRIPTION
These changes allowed me mitigate #194 and use the LetsEncrypt staging environment.

Adding the new service `IAdditionalIssuersSource` looked like the most flexible solution opposed to a list of certificates in the `LettuceEncryptOptions` and allows to combine different approaches.