### PR TITLE
feature: add API for configuring EAB (External Account Binding) credentials

### DIFF
--- a/src/LettuceEncrypt/Acme/EabCredentials.cs
+++ b/src/LettuceEncrypt/Acme/EabCredentials.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace LettuceEncrypt.Acme;
+
+/// <summary>
+/// External Account Binding (EAB) account credentials
+/// </summary>
+public class EabCredentials
+{
+    /// <summary>
+    /// Optional key identifier for external account binding
+    /// </summary>
+    public string? EabKeyId { get; set; }
+
+    /// <summary>
+    /// Optional key for use with external account binding
+    /// </summary>
+    public string? EabKey { get; set; }
+
+    /// <summary>
+    /// Optional key algorithm e.g HS256, for external account binding
+    /// </summary>
+    public string? EabKeyAlg { get; set; }
+}

--- a/src/LettuceEncrypt/Internal/AcmeClientFactory.cs
+++ b/src/LettuceEncrypt/Internal/AcmeClientFactory.cs
@@ -4,6 +4,7 @@
 using Certes;
 using LettuceEncrypt.Acme;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 
 namespace LettuceEncrypt.Internal;
 
@@ -11,19 +12,22 @@ internal class AcmeClientFactory
 {
     private readonly ICertificateAuthorityConfiguration _certificateAuthority;
     private readonly ILogger<AcmeClient> _logger;
+    private readonly IOptions<LettuceEncryptOptions> _options;
 
     public AcmeClientFactory(
         ICertificateAuthorityConfiguration certificateAuthority,
-        ILogger<AcmeClient> logger)
+        ILogger<AcmeClient> logger,
+        IOptions<LettuceEncryptOptions> options)
     {
         _certificateAuthority = certificateAuthority;
         _logger = logger;
+        _options = options;
     }
 
     public AcmeClient Create(IKey acmeAccountKey)
     {
         var directoryUri = _certificateAuthority.AcmeDirectoryUri;
 
-        return new AcmeClient(_logger, directoryUri, acmeAccountKey);
+        return new AcmeClient(_logger, _options, directoryUri, acmeAccountKey);
     }
 }

--- a/src/LettuceEncrypt/LettuceEncryptOptions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptOptions.cs
@@ -77,4 +77,9 @@ public class LettuceEncryptOptions
     /// Defaults to <see cref="ChallengeType.Any"/>.
     /// </summary>
     public ChallengeType AllowedChallengeTypes { get; set; } = ChallengeType.Any;
+
+    /// <summary>
+    /// Optional EAB (External Account Binding) account credentials used for creating new account.
+    /// </summary>
+    public EabCredentials EabCredentials { get; set; } = new();
 }

--- a/src/LettuceEncrypt/PublicAPI.Unshipped.txt
+++ b/src/LettuceEncrypt/PublicAPI.Unshipped.txt
@@ -1,1 +1,11 @@
 #nullable enable
+LettuceEncrypt.Acme.EabCredentials
+LettuceEncrypt.Acme.EabCredentials.EabCredentials() -> void
+LettuceEncrypt.Acme.EabCredentials.EabKey.get -> string?
+LettuceEncrypt.Acme.EabCredentials.EabKey.set -> void
+LettuceEncrypt.Acme.EabCredentials.EabKeyAlg.get -> string?
+LettuceEncrypt.Acme.EabCredentials.EabKeyAlg.set -> void
+LettuceEncrypt.Acme.EabCredentials.EabKeyId.get -> string?
+LettuceEncrypt.Acme.EabCredentials.EabKeyId.set -> void
+LettuceEncrypt.LettuceEncryptOptions.EabCredentials.get -> LettuceEncrypt.Acme.EabCredentials!
+LettuceEncrypt.LettuceEncryptOptions.EabCredentials.set -> void


### PR DESCRIPTION
Closes #251

This is required for ZeroSSL and other certificate authorities that require providing EAB credentials.