### PR TITLE
feat: allow configuring delay for validation

### DIFF
--- a/src/LettuceEncrypt/Internal/AcmeClient.cs
+++ b/src/LettuceEncrypt/Internal/AcmeClient.cs
@@ -117,7 +117,7 @@ internal class AcmeClient
             _logger.LogInformation("Awaiting {delayMs}ms before validating challenge", _options.Value.ChallengeValidationDelayMs);
             await Task.Delay(_options.Value.ChallengeValidationDelayMs);
         }
-        
+
         _logger.LogAcmeAction("ValidateChallenge", httpChallenge);
         return await httpChallenge.Validate();
     }

--- a/src/LettuceEncrypt/Internal/AcmeClient.cs
+++ b/src/LettuceEncrypt/Internal/AcmeClient.cs
@@ -112,6 +112,12 @@ internal class AcmeClient
 
     public async Task<Challenge> ValidateChallengeAsync(IChallengeContext httpChallenge)
     {
+        if (_options.Value.ChallengeValidationDelayMs > 0)
+        {
+            _logger.LogInformation("Awaiting {delayMs}ms before validating challenge", _options.Value.ChallengeValidationDelayMs);
+            await Task.Delay(_options.Value.ChallengeValidationDelayMs);
+        }
+        
         _logger.LogAcmeAction("ValidateChallenge", httpChallenge);
         return await httpChallenge.Validate();
     }

--- a/src/LettuceEncrypt/LettuceEncryptOptions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptOptions.cs
@@ -82,4 +82,9 @@ public class LettuceEncryptOptions
     /// Optional EAB (External Account Binding) account credentials used for creating new account.
     /// </summary>
     public EabCredentials EabCredentials { get; set; } = new();
+
+    /// <summary>
+    /// Optional delay in milliseconds before indicating that the challenge is ready for validation.
+    /// </summary>
+    public int ChallengeValidationDelayMs { get; set; } = 0;
 }

--- a/src/LettuceEncrypt/PublicAPI.Unshipped.txt
+++ b/src/LettuceEncrypt/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+LettuceEncrypt.LettuceEncryptOptions.ChallengeValidationDelayMs.get -> int
+LettuceEncrypt.LettuceEncryptOptions.ChallengeValidationDelayMs.set -> void


### PR DESCRIPTION
Fixes #254 

This PR adds an optional `ChallengeValidationDelayMs` to the configuration, allowing consumers to specify a delay before the challenge is ready for validation.

The delay happens in the `AcmeClient.ValidateChallengeAsync`, which is only used by the HTTP01 and TLSAlpn01 validators, as far as I can see. I don't know if it should rather be in the `Http01DomainValidator.PrepareHttpChallengeAsync` / `TlsAlpn01DomainValidator.PrepareTlsAlpnChallengeResponseAsync`, but there I don't have access to the configuration without changing the `AcmeCertificateFactory`.