### PR TITLE
Configurable certes verification certificates

### DIFF
--- a/src/LettuceEncrypt/Internal/AcmeCertificateFactory.cs
+++ b/src/LettuceEncrypt/Internal/AcmeCertificateFactory.cs
@@ -2,6 +2,7 @@
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
 using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using Certes;
 using Certes.Acme;
 using Certes.Acme.Resource;
@@ -291,6 +292,13 @@ internal class AcmeCertificateFactory
         _logger.LogAcmeAction("NewCertificate");
 
         var pfxBuilder = acmeCert.ToPfx(privateKey);
+
+        _logger.LogDebug("Adding {IssuerCount} additional issuers to certes before building pfx certificate file", _options.Value.AdditionalIssuers.Length);
+        foreach (var issuer in _options.Value.AdditionalIssuers)
+        {
+            pfxBuilder.AddIssuer(Encoding.UTF8.GetBytes(issuer));
+        }
+
         var pfx = pfxBuilder.Build("HTTPS Cert - " + _options.Value.DomainNames, string.Empty);
         return new X509Certificate2(pfx, string.Empty, X509KeyStorageFlags.Exportable);
     }

--- a/src/LettuceEncrypt/LettuceEncryptOptions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptOptions.cs
@@ -49,7 +49,7 @@ public class LettuceEncryptOptions
     internal bool UseStagingServerExplicitlySet => _useStagingServer.HasValue;
 
     /// <summary>
-    /// A certificate to use if a certifcates cannot be created automatically.
+    /// A certificate to use if a certificates cannot be created automatically.
     /// <para>
     /// This can be null if there is not fallback certificate.
     /// </para>

--- a/src/LettuceEncrypt/LettuceEncryptOptions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptOptions.cs
@@ -49,6 +49,17 @@ public class LettuceEncryptOptions
     internal bool UseStagingServerExplicitlySet => _useStagingServer.HasValue;
 
     /// <summary>
+    /// Additional issuers passed to certes before building the successfully downloaded certificate,
+    /// used internally by certes to verify the issuer for authenticity.
+    /// <para>
+    /// This is useful especially when using a staging server (e.g. for integration tests) with a root certificate
+    /// that is not part of certes' embedded resources.
+    /// See https://github.com/fszlin/certes/tree/v3.0.0/src/Certes/Resources/Certificates for context.
+    /// </para>
+    /// </summary>
+    public string[] AdditionalIssuers { get; set; } = Array.Empty<string>();
+
+    /// <summary>
     /// A certificate to use if a certificates cannot be created automatically.
     /// <para>
     /// This can be null if there is not fallback certificate.

--- a/src/LettuceEncrypt/PublicAPI.Unshipped.txt
+++ b/src/LettuceEncrypt/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+LettuceEncrypt.LettuceEncryptOptions.AdditionalIssuers.get -> string![]!
+LettuceEncrypt.LettuceEncryptOptions.AdditionalIssuers.set -> void

--- a/test/LettuceEncrypt.UnitTests/ConfigurationBindingTests.cs
+++ b/test/LettuceEncrypt.UnitTests/ConfigurationBindingTests.cs
@@ -75,6 +75,20 @@ public class ConfigurationBindingTests
             }));
     }
 
+    [Fact]
+    public void CanSetAdditionalIssuers()
+    {
+        var options = ParseOptions(new()
+        {
+            ["LettuceEncrypt:AdditionalIssuers:0"] = "-----BEGIN CERTIFICATE-----surely-a-certificate-----END CERTIFICATE-----",
+            ["LettuceEncrypt:AdditionalIssuers:1"] = "-----BEGIN CERTIFICATE-----surely-another-certificate-----END CERTIFICATE-----",
+        });
+
+        Assert.Collection(options.AdditionalIssuers,
+            one => Assert.Equal("-----BEGIN CERTIFICATE-----surely-a-certificate-----END CERTIFICATE-----", one),
+            two => Assert.Equal("-----BEGIN CERTIFICATE-----surely-another-certificate-----END CERTIFICATE-----", two));
+    }
+
     private LettuceEncryptOptions ParseOptions(Dictionary<string, string> input)
     {
         var config = new ConfigurationBuilder()

--- a/test/LettuceEncrypt.UnitTests/ConfigurationBindingTests.cs
+++ b/test/LettuceEncrypt.UnitTests/ConfigurationBindingTests.cs
@@ -89,7 +89,7 @@ public class ConfigurationBindingTests
             two => Assert.Equal("-----BEGIN CERTIFICATE-----surely-another-certificate-----END CERTIFICATE-----", two));
     }
 
-    private LettuceEncryptOptions ParseOptions(Dictionary<string, string> input)
+    private static LettuceEncryptOptions ParseOptions(Dictionary<string, string> input)
     {
         var config = new ConfigurationBuilder()
                    .AddInMemoryCollection(input)


### PR DESCRIPTION
Usage of the new API:

```
options.AdditionalIssuers = new[] { File.ReadAllText("letsencrypt-stg-root-x2.pem") };
```

When starting with e.g. the Staging Root certificate from Let's Encrypt, Lettuce Encrypt will still issue the following warning in the end:

> Failed to validate certificate for [certificate...]. This could cause an outage of your app.

This can be ignored.

## Why is this needed? What value does this PR add?

* Certes has a hard-coded amount of trusted root certificates. 
  * See https://github.com/fszlin/certes/tree/main/src/Certes/Resources/Certificates
  * That those are hardcoded, which is not optimal, is also mentioned here: https://github.com/fszlin/certes/pull/233#issuecomment-726581168
  * The x1 staging certificate is embedded in certes' dll, but it is outdated and unused by Let's Encrypt today.
* Certes has an API of `AddIssuer(s)` that can be used to add Certificates to that list of embedded certificates.
* Exposing this API through Lettuce Encrypt allows it to be configured for any other ACME/certes compatible service - including the current Let's Encrypt staging server, without updating certes' embedded certificates.
* This PR probably reduces the future maintenance effort of Lettuce Encrypt and/or amount of Issues. There are a certain amount of forks that do nothing other than adding such root certificates (in the same place as this PR), but hard-coded.

### Related issues

This PR is likely the "extension point" you talked about in this comment: https://github.com/natemcmaster/LettuceEncrypt/pull/230#issuecomment-967759204 

This PR may partially solve issues such as #274, I am not very confident in that assessment however. 

It may also make #263 possible - I don't think your proposed solution was sufficient as certes should to my understanding throw because the google acme server's root certificate isn't well known. I may be wrong here as well.

It for sure solves #278, as I have tested that myself. The pull requests #276 and #277 were initial steps/solutions to getting LettuceEncrypt running in a project using the staging server with ngrok (v3) and the current version of LettuceEncrypt. I would recommend taking a look at them as well.

Additionally, once the `dst-root-ca-x3.pem` expires in 2030 and the `isrg-root-x1.pem` expires in 2035,
Lettuce Encrypt will have to upgrade certes (if certes adds the new certificates as embedded resources) or manually pass in the new Let's Encrypt root certificate every time. This change will be less dramatic/annoying with this PR, as users of Lettuce Encrypt can workaround/fix this "problem" themselves without having to upgrade any packages to a new version.

### Alternative Architecture considerations
Another way of adding the functionality contained in this PR would be to add the additional certificates to `ICertificateAuthorityConfiguration`, as it kind of belongs there. I realized this looking at a comment in #263.