### PR TITLE
feature: add dns-01 validation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ offering** from Let's Encrypt® or ISRG™.
 
 This project is 100% organic and best served cold with ranch and carrots. 🥬
 
-### Project status 
+### Project status
 
 This project is in maintenance mode. I lost interest in developing features. I will make a patch if there is a security issue. I'll also consider an update if a new .NET major version breaks and the patch fix required is small. Please see https://github.com/natemcmaster/LettuceEncrypt/security/policy if you wish to report a security concern.
 
@@ -262,7 +262,8 @@ giving up.
 Current supported values:
 * `Http01` - The HTTP-01 challenge, which uses a well-known URL on the server and a HTTP request/response.
 * `TlsAlpn01` - The TLS-ALPN-01 challenge, which uses an auto-generated, ephemeral certificate in the TLS handshake.
-* `Any` - _(default)_ - use HTTP-01 and/or TLS-ALPN-01
+* `Dns01` - The DNS-01 challenge, which uses TXT record under that domain name.
+* `Any` - _(default)_ - use HTTP-01 and/or TLS-ALPN-01 DNS-01
 
 Tip: if you wish to set multiple method types and are use the "appsettings.json" approach, provide a comma-seperated list.
 
@@ -270,11 +271,34 @@ Tip: if you wish to set multiple method types and are use the "appsettings.json"
 ```json
 {
     "LettuceEncrypt": {
-        "AllowedChallengeTypes": "Http01, TlsAlpn01"
+        "AllowedChallengeTypes": "Http01, TlsAlpn01, Dns01"
     }
 }
 ```
 
+
+### When using DNS-01
+
+When using the DNS-01 challenge a `IDnsChallengeProvider` must be add and replace the `NoOpDnsChallengeProvider`
+
+```c#
+public class MyDnsChallengeProvider : IDnsChallengeProvider
+{
+    private readonly ISomeExternalDnsClient _client;
+
+    public MyDnsChallengeProvider(ISomeExternalDnsClient client) => _client = client;
+
+    public Task AddTxtRecordAsync(string domainName, string txt, CancellationToken ct = default)
+    {
+        return _client.AddDnsTxtRecord(domainName, txt, ct);
+    }
+
+    public Task RemoveTxtRecordAsync(string domainName, string txt, CancellationToken ct = default)
+    {
+        return _client.RemoveDnsTxtRecord(domainName, txt, ct);
+    }
+}
+```
 
 ## Testing in development
 

--- a/src/LettuceEncrypt.Azure/Internal/AzureKeyVaultCertificateRepository.cs
+++ b/src/LettuceEncrypt.Azure/Internal/AzureKeyVaultCertificateRepository.cs
@@ -173,5 +173,7 @@ internal class AzureKeyVaultCertificateRepository : ICertificateRepository, ICer
     /// Names must follow the regular expression <c>/^[0-9a-zA-Z-]+$/</c>
     /// See https://docs.microsoft.com/en-us/rest/api/keyvault/ImportCertificate/ImportCertificate.
     /// </summary>
-    internal static string NormalizeHostName(string hostName) => hostName.Replace(".", "-");
+    internal static string NormalizeHostName(string hostName) =>
+        hostName.Replace(".", "-")
+            .Replace("*", "-");
 }

--- a/src/LettuceEncrypt/Acme/ChallengeType.cs
+++ b/src/LettuceEncrypt/Acme/ChallengeType.cs
@@ -23,6 +23,12 @@ public enum ChallengeType
     TlsAlpn01 = 1 << 1,
 
     /// <summary>
+    /// The DNS-01 challenge, which uses TXT record under that domain name.
+    /// See https://letsencrypt.org/docs/challenge-types/#dns-01-challenge
+    /// </summary>
+    Dns01 = 1 << 2,
+
+    /// <summary>
     /// A special flag which represents all known challenge types.
     /// </summary>
     Any = 0xFFFF,

--- a/src/LettuceEncrypt/Internal/AcmeClient.cs
+++ b/src/LettuceEncrypt/Internal/AcmeClient.cs
@@ -14,12 +14,14 @@ internal class AcmeClient
     private readonly AcmeContext _context;
     private readonly ILogger<AcmeClient> _logger;
     private readonly IOptions<LettuceEncryptOptions> _options;
+    private readonly IKey _acmeAccountKey;
     private IAccountContext? _accountContext;
 
     public AcmeClient(ILogger<AcmeClient> logger, IOptions<LettuceEncryptOptions> options, Uri directoryUri, IKey acmeAccountKey)
     {
         _logger = logger;
         _options = options;
+        _acmeAccountKey = acmeAccountKey;
         _logger.LogInformation("Using certificate authority {directoryUri}", directoryUri);
         _context = new AcmeContext(directoryUri, acmeAccountKey);
     }
@@ -30,6 +32,12 @@ internal class AcmeClient
         _accountContext = await _context.Account();
         _logger.LogAcmeAction("FetchAccountDetails", _accountContext);
         return await _accountContext.Resource();
+    }
+
+    public IKey? GetAccountKey()
+    {
+        _logger.LogAcmeAction("GetAccountKey");
+        return _acmeAccountKey;
     }
 
     public async Task<int> CreateAccountAsync(string emailAddress)

--- a/src/LettuceEncrypt/Internal/DefaultTxtRecordContext.cs
+++ b/src/LettuceEncrypt/Internal/DefaultTxtRecordContext.cs
@@ -1,0 +1,30 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace LettuceEncrypt.Internal;
+
+/// <summary>
+/// Default txt record context
+/// </summary>
+public class DefaultTxtRecordContext : ITxtRecordContext
+{
+    /// <summary>
+    /// default constructor
+    /// </summary>
+    /// <param name="domainName">Domain name for the txt record</param>
+    /// <param name="txt">TXT record Value</param>
+    public DefaultTxtRecordContext(string domainName, string txt)
+    {
+        DomainName = domainName;
+        Txt = txt;
+    }
+
+    /// <summary>
+    /// Domain name for the txt record
+    /// </summary>
+    public string DomainName { get; }
+    /// <summary>
+    /// TXT record Value
+    /// </summary>
+    public string Txt { get; }
+}

--- a/src/LettuceEncrypt/Internal/Dns01DomainValidator.cs
+++ b/src/LettuceEncrypt/Internal/Dns01DomainValidator.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using Certes;
+using Certes.Acme;
+using Certes.Acme.Resource;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace LettuceEncrypt.Internal;
+
+internal class Dns01DomainValidator : DomainOwnershipValidator
+{
+    private readonly IDnsChallengeProvider _dnsChallengeProvider;
+
+    public Dns01DomainValidator(
+        IDnsChallengeProvider dnsChallengeProvider,
+        IHostApplicationLifetime appLifetime,
+        AcmeClient client,
+        ILogger logger,
+        string domainName
+    ) : base(appLifetime, client, logger, domainName)
+    {
+        _dnsChallengeProvider = dnsChallengeProvider;
+    }
+
+    public override async Task ValidateOwnershipAsync(
+        IAuthorizationContext authzContext,
+        CancellationToken cancellationToken
+    )
+    {
+        ITxtRecordContext context = new DefaultTxtRecordContext(_domainName, string.Empty);
+        try
+        {
+            context = await PrepareDns01ChallengeResponseAsync(authzContext, _domainName, cancellationToken);
+            await WaitForChallengeResultAsync(authzContext, cancellationToken);
+        }
+        finally
+        {
+            // Cleanup
+            await _dnsChallengeProvider.RemoveTxtRecordAsync(context, cancellationToken);
+        }
+    }
+
+    private async Task<ITxtRecordContext> PrepareDns01ChallengeResponseAsync(
+        IAuthorizationContext authorizationContext,
+        string domainName,
+        CancellationToken cancellationToken
+    )
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var account = _client.GetAccountKey();
+        var dnsChallenge = await _client.CreateChallengeAsync(authorizationContext, ChallengeTypes.Dns01);
+
+        var dnsTxt = account.DnsTxt(dnsChallenge.Token);
+
+        var acmeDomain = GetAcmeDnsDomain(domainName);
+
+        var context = await _dnsChallengeProvider.AddTxtRecordAsync(acmeDomain, dnsTxt, cancellationToken);
+
+        _logger.LogTrace("Requesting server to validate DNS challenge");
+        await _client.ValidateChallengeAsync(dnsChallenge);
+
+        return context;
+    }
+
+    private const string DnsAcmePrefix = "_acme-challenge";
+
+    private string GetAcmeDnsDomain(string domainName) =>
+        $"{DnsAcmePrefix}.{domainName.TrimStart('*')}";
+}

--- a/src/LettuceEncrypt/Internal/IDnsChallengeProvider.cs
+++ b/src/LettuceEncrypt/Internal/IDnsChallengeProvider.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace LettuceEncrypt.Internal;
+
+/// <summary>
+/// External Dns provider to update for DNS-01 challenge
+/// </summary>
+public interface IDnsChallengeProvider
+{
+    /// <summary>
+    /// call to add record in advance of the validation
+    /// </summary>
+    /// <param name="domainName">domain name including _acme-challenge.	&lt;YOUR_DOMAIN&gt;</param>
+    /// <param name="txt">TXT value for DNS-01 Challenge</param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns>context of added txt record</returns>
+    Task<ITxtRecordContext> AddTxtRecordAsync(string domainName, string txt, CancellationToken ct = default);
+
+    /// <summary>
+    /// callback to remove dns record after validations
+    /// </summary>
+    /// <param name="context">context from previous added txt record</param>
+    /// <param name="ct">A cancellation token.</param>
+    /// <returns></returns>
+    Task RemoveTxtRecordAsync(ITxtRecordContext context, CancellationToken ct = default);
+}

--- a/src/LettuceEncrypt/Internal/ITxtRecordContext.cs
+++ b/src/LettuceEncrypt/Internal/ITxtRecordContext.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace LettuceEncrypt.Internal;
+
+/// <summary>
+/// Context returned from dns update
+/// </summary>
+public interface ITxtRecordContext
+{
+    /// <summary>
+    /// Domain name for the txt record
+    /// </summary>
+    string DomainName { get; }
+    /// <summary>
+    /// TXT record Value
+    /// </summary>
+    string Txt { get; }
+}

--- a/src/LettuceEncrypt/Internal/NoOpDnsChallengeProvider.cs
+++ b/src/LettuceEncrypt/Internal/NoOpDnsChallengeProvider.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Nate McMaster.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace LettuceEncrypt.Internal;
+
+internal class NoOpDnsChallengeProvider : IDnsChallengeProvider
+{
+    public Task<ITxtRecordContext> AddTxtRecordAsync(
+        string domainName,
+        string txt,
+        CancellationToken ct = default
+    ) => Task.FromResult((ITxtRecordContext)new DefaultTxtRecordContext(domainName, txt));
+
+    public Task RemoveTxtRecordAsync(ITxtRecordContext context, CancellationToken ct = default) =>
+        Task.CompletedTask;
+}

--- a/src/LettuceEncrypt/Internal/OptionsValidation.cs
+++ b/src/LettuceEncrypt/Internal/OptionsValidation.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Nate McMaster.
 // Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
 
+using LettuceEncrypt.Acme;
 using Microsoft.Extensions.Options;
 
 namespace LettuceEncrypt.Internal;
@@ -9,6 +10,9 @@ internal class OptionsValidation : IValidateOptions<LettuceEncryptOptions>
 {
     public ValidateOptionsResult Validate(string name, LettuceEncryptOptions options)
     {
+        if (options.AllowedChallengeTypes == ChallengeType.Dns01)
+            return ValidateOptionsResult.Success;
+
         foreach (var dnsName in options.DomainNames)
         {
             if (dnsName.Contains('*'))

--- a/src/LettuceEncrypt/LettuceEncryptServiceCollectionExtensions.cs
+++ b/src/LettuceEncrypt/LettuceEncryptServiceCollectionExtensions.cs
@@ -64,7 +64,8 @@ public static class LettuceEncryptServiceCollectionExtensions
             .AddSingleton<ICertificateRepository>(x => x.GetRequiredService<X509CertStore>())
             .AddSingleton<HttpChallengeResponseMiddleware>()
             .AddSingleton<TlsAlpnChallengeResponder>()
-            .AddSingleton<IStartupFilter, HttpChallengeStartupFilter>();
+            .AddSingleton<IStartupFilter, HttpChallengeStartupFilter>()
+            .AddSingleton<IDnsChallengeProvider, NoOpDnsChallengeProvider>();
 
         services.AddSingleton<IConfigureOptions<LettuceEncryptOptions>>(s =>
         {

--- a/src/LettuceEncrypt/PublicAPI.Unshipped.txt
+++ b/src/LettuceEncrypt/PublicAPI.Unshipped.txt
@@ -1,3 +1,14 @@
 #nullable enable
+LettuceEncrypt.Acme.ChallengeType.Dns01 = 4 -> LettuceEncrypt.Acme.ChallengeType
+LettuceEncrypt.Internal.DefaultTxtRecordContext
+LettuceEncrypt.Internal.DefaultTxtRecordContext.DefaultTxtRecordContext(string! domainName, string! txt) -> void
+LettuceEncrypt.Internal.DefaultTxtRecordContext.DomainName.get -> string!
+LettuceEncrypt.Internal.DefaultTxtRecordContext.Txt.get -> string!
+LettuceEncrypt.Internal.IDnsChallengeProvider
+LettuceEncrypt.Internal.IDnsChallengeProvider.AddTxtRecordAsync(string! domainName, string! txt, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<LettuceEncrypt.Internal.ITxtRecordContext!>!
+LettuceEncrypt.Internal.IDnsChallengeProvider.RemoveTxtRecordAsync(LettuceEncrypt.Internal.ITxtRecordContext! context, System.Threading.CancellationToken ct = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task!
+LettuceEncrypt.Internal.ITxtRecordContext
+LettuceEncrypt.Internal.ITxtRecordContext.DomainName.get -> string!
+LettuceEncrypt.Internal.ITxtRecordContext.Txt.get -> string!
 LettuceEncrypt.LettuceEncryptOptions.AdditionalIssuers.get -> string![]!
 LettuceEncrypt.LettuceEncryptOptions.AdditionalIssuers.set -> void


### PR DESCRIPTION
Hi! 

Added dns-01 validation. im using this i Azure container apps to add certs with the container app env as certificate source. Very new to this so happy for all feedback.

and in order to get this working behind a reverse proxy im adding this and binding the dns with cert in other code
```c#
var lettuceKesterConfig =  builder.Services.FirstOrDefault(
                x => x.ServiceType.FullName == "LettuceEncrypt.Internal.KestrelOptionsSetup");
if (lettuceKesterConfig != null)
    builder.Services.Remove(lettuceKesterConfig);

```