### PR TITLE
Fix fallback to default certificate configuration

### DIFF
--- a/src/Kestrel.Certificates/IServerCertificateSelector.cs
+++ b/src/Kestrel.Certificates/IServerCertificateSelector.cs
@@ -20,5 +20,5 @@ public interface IServerCertificateSelector
     /// If the server certificate has an Extended Key Usage extension, the usages must include Server Authentication (OID 1.3.6.1.5.5.7.3.1).
     /// </para>
     /// </summary>
-    X509Certificate2? Select(ConnectionContext context, string? domainName);
+    public Func<ConnectionContext?, string?, X509Certificate2?>? ServerCertificateSelector { get; }
 }

--- a/src/Kestrel.Certificates/KestrelHttpsOptionsExtensions.cs
+++ b/src/Kestrel.Certificates/KestrelHttpsOptionsExtensions.cs
@@ -22,7 +22,7 @@ public static class KestrelHttpsOptionsExtensions
         this HttpsConnectionAdapterOptions httpsOptions,
         IServerCertificateSelector certificateSelector)
     {
-        httpsOptions.ServerCertificateSelector = certificateSelector.Select!;
+        httpsOptions.ServerCertificateSelector = certificateSelector.ServerCertificateSelector;
         return httpsOptions;
     }
 }

--- a/src/Kestrel.Certificates/PublicAPI.Shipped.txt
+++ b/src/Kestrel.Certificates/PublicAPI.Shipped.txt
@@ -1,5 +1,4 @@
 #nullable enable
 McMaster.AspNetCore.Kestrel.Certificates.IServerCertificateSelector
-McMaster.AspNetCore.Kestrel.Certificates.IServerCertificateSelector.Select(Microsoft.AspNetCore.Connections.ConnectionContext! context, string? domainName) -> System.Security.Cryptography.X509Certificates.X509Certificate2?
 Microsoft.AspNetCore.Hosting.KestrelHttpsOptionsExtensions
 static Microsoft.AspNetCore.Hosting.KestrelHttpsOptionsExtensions.UseServerCertificateSelector(this Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions! httpsOptions, McMaster.AspNetCore.Kestrel.Certificates.IServerCertificateSelector! certificateSelector) -> Microsoft.AspNetCore.Server.Kestrel.Https.HttpsConnectionAdapterOptions!

--- a/src/Kestrel.Certificates/PublicAPI.Unshipped.txt
+++ b/src/Kestrel.Certificates/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 #nullable enable
+McMaster.AspNetCore.Kestrel.Certificates.IServerCertificateSelector.ServerCertificateSelector.get -> System.Func<Microsoft.AspNetCore.Connections.ConnectionContext?, string?, System.Security.Cryptography.X509Certificates.X509Certificate2?>?

--- a/src/LettuceEncrypt/Internal/CertificateSelector.cs
+++ b/src/LettuceEncrypt/Internal/CertificateSelector.cs
@@ -86,6 +86,18 @@ internal class CertificateSelector : IServerCertificateSelector
 
     public bool HasCertForDomain(string domainName) => _certs.ContainsKey(domainName);
 
+    public Func<ConnectionContext?, string?, X509Certificate2?>? ServerCertificateSelector
+    {
+        get
+        {
+            if(_certs.Count == 0 && _challengeCerts.Count == 0)
+            {
+                return null;
+            }
+            return Select!;
+        }
+    }
+
     public X509Certificate2? Select(ConnectionContext context, string? domainName)
     {
         if (_challengeCerts.Count > 0)


### PR DESCRIPTION
This fixes [#122 Requests without SNI fail with: "The server mode SSL must use a certificate with the associated private key."](https://github.com/natemcmaster/LettuceEncrypt/issues/122)

Basically when setting a ServerCertificateSelector it overrides the default behavior, returning null will give an error instead of falling back to the configuration. 
This change only sets the ServerCertificateSelector whenever domains are configured. To do this however I had to break the API.